### PR TITLE
Fix Clippy issue with SmartstateProvider::next()

### DIFF
--- a/examples/basic-example-incremental-redraw.rs
+++ b/examples/basic-example-incremental-redraw.rs
@@ -92,27 +92,32 @@ fn main() -> Result<(), core::convert::Infallible> {
         ui.add(
             Label::new("Basic Example (incremental)")
                 .with_font(ascii::FONT_10X20)
-                .smartstate(smartstates.next()),
+                .smartstate(smartstates.nxt()),
         );
 
         // Smartstates of labels are never redrawn, unless they are forced to be.
-        ui.add(Label::new("Basic Counter (7LOC)").smartstate(smartstates.next()));
+        ui.add(Label::new("Basic Counter (7LOC)").smartstate(smartstates.nxt()));
 
         // Smartstates of buttons are redrawn when they are interacted with.
         if ui
-            .add_horizontal(Button::new("-").smartstate(smartstates.next()))
+            .add_horizontal(Button::new("-").smartstate(smartstates.nxt()))
             .clicked()
         {
             i = i.saturating_sub(1);
 
             // force smartstate of label to be redrawn if the button is clicked
-            smartstates.next().force_redraw();
+            smartstates.nxt().force_redraw();
         }
         ui.add_horizontal(
-            Label::new(&format!("Clicked {} times", i)).smartstate(smartstates.next()),
+            Label::new(&format!(
+                "Clicked {} times{}",
+                i,
+                " ".repeat(3 - (i.max(1).ilog10()) as usize)
+            ))
+            .smartstate(smartstates.nxt()),
         );
         if ui
-            .add_horizontal(Button::new("+").smartstate(smartstates.next()))
+            .add_horizontal(Button::new("+").smartstate(smartstates.nxt()))
             .clicked()
         {
             i = i.saturating_add(1);

--- a/examples/keyboard.rs
+++ b/examples/keyboard.rs
@@ -71,7 +71,7 @@ fn main() -> Result<(), core::convert::Infallible> {
 
         let text_smartstate = smartstates.get_pos();
         ui.add_and_clear_col_remainder(
-            Label::new(format!("Text: {}", text).as_ref()).smartstate(smartstates.next()),
+            Label::new(format!("Text: {}", text).as_ref()).smartstate(smartstates.nxt()),
             last_len > text.len(),
         );
         last_len = text.len();
@@ -81,7 +81,7 @@ fn main() -> Result<(), core::convert::Infallible> {
 
         ui.expand_row_height(20);
         if ui
-            .add_horizontal(Button::new("Open Keyboard").smartstate(smartstates.next()))
+            .add_horizontal(Button::new("Open Keyboard").smartstate(smartstates.nxt()))
             .clicked()
         {
             open = true;

--- a/examples/motion-scheduler.rs
+++ b/examples/motion-scheduler.rs
@@ -334,12 +334,12 @@ fn main() -> Result<(), core::convert::Infallible> {
 
         // === UI ===
 
-        ui.add_horizontal(StepWidget::new(&mut step).smartstate(smartstates.next()));
-        ui.add_horizontal(StepWidget::new(&mut step1).smartstate(smartstates.next()));
-        ui.add_horizontal(StepWidget::new(&mut step11).smartstate(smartstates.next()));
-        ui.add_horizontal(StepWidget::new(&mut step2).smartstate(smartstates.next()));
-        ui.add_horizontal(StepWidget::new(&mut step2).smartstate(smartstates.next()));
-        ui.add(StepWidget::new(&mut step2).smartstate(smartstates.next()));
+        ui.add_horizontal(StepWidget::new(&mut step).smartstate(smartstates.nxt()));
+        ui.add_horizontal(StepWidget::new(&mut step1).smartstate(smartstates.nxt()));
+        ui.add_horizontal(StepWidget::new(&mut step11).smartstate(smartstates.nxt()));
+        ui.add_horizontal(StepWidget::new(&mut step2).smartstate(smartstates.nxt()));
+        ui.add_horizontal(StepWidget::new(&mut step2).smartstate(smartstates.nxt()));
+        ui.add(StepWidget::new(&mut step2).smartstate(smartstates.nxt()));
 
         // === END UI ===
 

--- a/src/helpers/keyboard.rs
+++ b/src/helpers/keyboard.rs
@@ -535,7 +535,7 @@ pub fn draw_keyboard<
 
     let redraw = smartstates
         .as_mut()
-        .map(|smp| smp.next())
+        .map(|smp| smp.nxt())
         .map(|sm| {
             // if the state is not the same as open, redraw (=> open has changed)
             let redraw = !sm.is_state(*open as u16);
@@ -587,7 +587,7 @@ pub fn draw_keyboard<
             let mut button = Button::new(btn_char.encode_utf8(&mut buf));
 
             if let Some(smartstates) = smartstates.as_mut() {
-                button = button.smartstate(smartstates.next());
+                button = button.smartstate(smartstates.nxt());
             }
 
             if ui.add_horizontal(button).clicked() {
@@ -617,7 +617,7 @@ pub fn draw_keyboard<
         let mut button = Button::new(btn_char.encode_utf8(&mut buf));
 
         if let Some(smartstates) = smartstates.as_mut() {
-            button = button.smartstate(smartstates.next());
+            button = button.smartstate(smartstates.nxt());
         }
 
         if ui.add_horizontal(button).clicked() {
@@ -659,7 +659,7 @@ pub fn draw_keyboard<
         let mut button = Button::new(btn_char.encode_utf8(&mut buf));
 
         if let Some(smartstates) = smartstates.as_mut() {
-            button = button.smartstate(smartstates.next());
+            button = button.smartstate(smartstates.nxt());
         }
 
         if ui.add_horizontal(button).clicked() {
@@ -694,7 +694,7 @@ pub fn draw_keyboard<
         let mut button = Button::new(btn_char.encode_utf8(&mut buf));
 
         if let Some(smartstates) = smartstates.as_mut() {
-            button = button.smartstate(smartstates.next());
+            button = button.smartstate(smartstates.nxt());
         }
 
         if ui.add_horizontal(button).clicked() {
@@ -714,7 +714,7 @@ pub fn draw_keyboard<
             .add({
                 let b = IconButton::<size16px::navigation::NavArrowUp>::new_from_type();
                 if let Some(smartstates) = smartstates.as_mut() {
-                    b.smartstate(smartstates.next())
+                    b.smartstate(smartstates.nxt())
                 } else {
                     b
                 }
@@ -753,7 +753,7 @@ pub fn draw_keyboard<
         .add_horizontal({
             let b = Button::new("|                |");
             if let Some(smartstates) = smartstates.as_mut() {
-                b.smartstate(smartstates.next())
+                b.smartstate(smartstates.nxt())
             } else {
                 b
             }
@@ -770,7 +770,7 @@ pub fn draw_keyboard<
         .add({
             let b = IconButton::<size16px::navigation::NavArrowDown>::new_from_type();
             if let Some(smartstates) = smartstates.as_mut() {
-                b.smartstate(smartstates.next())
+                b.smartstate(smartstates.nxt())
             } else {
                 b
             }

--- a/src/smartstate.rs
+++ b/src/smartstate.rs
@@ -227,12 +227,12 @@ impl<const N: usize> SmartstateProvider<N> {
         self.states
             .get_mut((self.pos as i32 + pos) as usize)
             .expect(
-                "ERROR: Smartstate Index out of range! Did you call get_relative() before next()?",
+                "ERROR: Smartstate Index out of range! Did you call get_relative() before nxt()?",
             )
     }
 
     #[inline(always)]
-    pub fn next(&mut self) -> &mut Smartstate {
+    pub fn nxt(&mut self) -> &mut Smartstate {
         let state = self
             .states
             .get_mut(self.pos)
@@ -245,14 +245,14 @@ impl<const N: usize> SmartstateProvider<N> {
     pub fn current(&mut self) -> &mut Smartstate {
         self.states
             .get_mut(self.pos - 1)
-            .expect("ERROR: Smartstate Index out of range! Did you call current() before next()?")
+            .expect("ERROR: Smartstate Index out of range! Did you call current() before nxt()?")
     }
 
     #[inline(always)]
     pub fn prev(&mut self) -> &mut Smartstate {
         self.states
             .get_mut(self.pos - 2)
-            .expect("ERROR: Smartstate Index out of range! Did you call prev() before 2 * next()?")
+            .expect("ERROR: Smartstate Index out of range! Did you call prev() before 2 * nxt()?")
     }
 
     #[inline(always)]


### PR DESCRIPTION
Simple fix: `next()` -> `nxt()`

This is still simple, easy to read, basically the same as next, but even shorter. Overall seems like a good replacement I think