### PR TITLE
Draft: feat: change widgets to contain color generic param, and add with_col…

### DIFF
--- a/examples/experimenting.rs
+++ b/examples/experimenting.rs
@@ -1,6 +1,7 @@
 use embedded_graphics::geometry::Size;
+use embedded_graphics::mono_font::ascii;
 use embedded_graphics::pixelcolor::Rgb565;
-use embedded_graphics::prelude::Point;
+use embedded_graphics::prelude::{Point, WebColors};
 use embedded_graphics_simulator::sdl2::MouseButton;
 use embedded_graphics_simulator::{
     OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
@@ -9,7 +10,7 @@ use kolibri_embedded_gui::button::Button;
 use kolibri_embedded_gui::icon::IconWidget;
 use kolibri_embedded_gui::iconbutton::IconButton;
 use kolibri_embedded_gui::icons::size24px;
-use kolibri_embedded_gui::label::{HashLabel, Hasher};
+use kolibri_embedded_gui::label::{HashLabel, Hasher, Label};
 use kolibri_embedded_gui::slider::Slider;
 use kolibri_embedded_gui::smartstate::SmartstateProvider;
 use kolibri_embedded_gui::style::*;
@@ -68,6 +69,12 @@ fn main() -> Result<(), core::convert::Infallible> {
         }
 
         last_down = mouse_down;
+
+        ui.add(
+            Label::new("Experimenting Example")
+                .with_font(ascii::FONT_10X20)
+                .with_color(Rgb565::CSS_BLUE_VIOLET),
+        );
 
         if ui
             .add_horizontal(Button::new("Something").smartstate(smartstates.nxt()))

--- a/examples/motion-scheduler.rs
+++ b/examples/motion-scheduler.rs
@@ -60,8 +60,8 @@ enum ButtonPress {
     Center,
 }
 
-impl Widget for StepWidget<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for StepWidget<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/button.rs
+++ b/src/button.rs
@@ -112,8 +112,8 @@ impl<'a> Button<'a> {
     }
 }
 
-impl Widget for Button<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Button<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/checkbox.rs
+++ b/src/checkbox.rs
@@ -124,8 +124,8 @@ impl Checkbox<'_> {
     }
 }
 
-impl Widget for Checkbox<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Checkbox<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -111,7 +111,7 @@ impl<'a, Ico: IconoirIcon> IconWidget<'a, Ico> {
     }
 }
 
-impl<Ico: IconoirIcon> Widget for IconWidget<'_, Ico> {
+impl<COL: PixelColor, Ico: IconoirIcon> Widget<COL> for IconWidget<'_, Ico> {
     /// Draws the icon within the UI.
     ///
     /// This method:
@@ -120,7 +120,7 @@ impl<Ico: IconoirIcon> Widget for IconWidget<'_, Ico> {
     /// 3. Updates the smartstate
     /// 4. Draws the icon if necessary (when smartstate changes or is forced to redraw)
     /// 5. Centers the icon vertically within the allocated space
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/iconbutton.rs
+++ b/src/iconbutton.rs
@@ -223,7 +223,7 @@ impl<'a, ICON: IconoirIcon> IconButton<'a, ICON> {
     }
 }
 
-impl<ICON: IconoirIcon> Widget for IconButton<'_, ICON> {
+impl<COL: PixelColor, ICON: IconoirIcon> Widget<COL> for IconButton<'_, ICON> {
     /// Draws the icon button within the UI.
     ///
     /// This method:
@@ -234,7 +234,7 @@ impl<ICON: IconoirIcon> Widget for IconButton<'_, ICON> {
     /// 5. Manages visual appearance based on interaction state
     /// 6. Updates the smartstate and draws when necessary
     /// 7. Returns a response that includes click information
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -192,8 +192,8 @@ impl<'a> Slider<'a> {
     }
 }
 
-impl Widget for Slider<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Slider<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/spacer.rs
+++ b/src/spacer.rs
@@ -64,8 +64,8 @@ impl Spacer {
     }
 }
 
-impl Widget for Spacer {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Spacer {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/toggle_button.rs
+++ b/src/toggle_button.rs
@@ -116,8 +116,8 @@ impl<'a> ToggleButton<'a> {
     }
 }
 
-impl Widget for ToggleButton<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for ToggleButton<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/toggle_switch.rs
+++ b/src/toggle_switch.rs
@@ -155,8 +155,8 @@ impl<'a> ToggleSwitch<'a> {
     }
 }
 
-impl Widget for ToggleSwitch<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for ToggleSwitch<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -155,8 +155,8 @@ impl Response {
     }
 }
 
-pub trait Widget {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+pub trait Widget<COL: PixelColor> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response>;
@@ -774,7 +774,11 @@ where
     /// # let mut widget = Label::new("Hi");
     /// let response = ui.add_and_clear_col_remainder(widget, true);
     /// ```
-    pub fn add_and_clear_col_remainder(&mut self, widget: impl Widget, clear: bool) -> Response {
+    pub fn add_and_clear_col_remainder(
+        &mut self,
+        widget: impl Widget<COL>,
+        clear: bool,
+    ) -> Response {
         let resp = self.add_raw(widget).unwrap_or_else(Response::from_error);
         if clear {
             self.clear_row_to_end().ok();
@@ -810,7 +814,7 @@ where
     /// # let mut widget = Label::new("Hi");
     /// let response = ui.add(widget);
     /// ```
-    pub fn add(&mut self, widget: impl Widget) -> Response {
+    pub fn add(&mut self, widget: impl Widget<COL>) -> Response {
         let resp = self.add_raw(widget).unwrap_or_else(Response::from_error);
         self.new_row();
         resp
@@ -843,7 +847,7 @@ where
     /// # let mut widget = Label::new("Hi");
     /// let response = ui.add_centered(widget);
     /// ```
-    pub fn add_centered(&mut self, widget: impl Widget) -> Response {
+    pub fn add_centered(&mut self, widget: impl Widget<COL>) -> Response {
         let align = self.placer.align;
         self.placer.align = Align(HorizontalAlign::Center, align.1);
         let resp = self.add_raw(widget).unwrap_or_else(Response::from_error);
@@ -879,7 +883,7 @@ where
     /// # let mut widget = Label::new("Hi");
     /// let response = ui.add_horizontal(widget);
     /// ```
-    pub fn add_horizontal(&mut self, widget: impl Widget) -> Response {
+    pub fn add_horizontal(&mut self, widget: impl Widget<COL>) -> Response {
         let resp = self.add_raw(widget).unwrap_or_else(Response::from_error);
         // Allocate space between widgets; ignore space errors.
         self.allocate_space_no_wrap(self.style().spacing.item_spacing)
@@ -917,7 +921,7 @@ where
     ///     Err(e) => { /* handle error */ },
     /// }
     /// ```
-    pub fn add_raw(&mut self, mut widget: impl Widget) -> GuiResult<Response> {
+    pub fn add_raw(&mut self, mut widget: impl Widget<COL>) -> GuiResult<Response> {
         let res = widget.draw(self);
         if let (Ok(res), Some(debug_color)) = (&res, self.debug_color) {
             res.internal


### PR DESCRIPTION
This PR does the following: 

# Update to the `Widget` trait
From:
```rust
pub trait Widget {
    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
        &mut self,
        ui: &mut Ui<DRAW, COL>,
    ) -> GuiResult<Response>;
}
```

To:

```rust
pub trait Widget<COL: PixelColor> {
    fn draw<DRAW: DrawTarget<Color = COL>>(
        &mut self,
        ui: &mut Ui<DRAW, COL>,
    ) -> GuiResult<Response>;
}
```

This update allows setting colors in widgets, while not increasing trait implementation difficulty significantly. 

Please note that this is a **BREAKING CHANGE**! All existing widget traits need to be adjusted like this: 

```rust
// FROM
impl Widget for Button<'_> {
    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
        &mut self,
        ui: &mut Ui<DRAW, COL>,
    ) -> GuiResult<Response> {

// TO
impl<COL: PixelColor> Widget<COL> for Button<'_> {
    fn draw<DRAW: DrawTarget<Color = COL>>(
        &mut self,
        ui: &mut Ui<DRAW, COL>,
    ) -> GuiResult<Response> {
```

No other changes are necessary. 

## `with_color` function for labels

Labels now have a `with_color` function that lets a user adjust the label's color without changing the backing style.
All current functionality is preserved. No type hints need to be given - type inference takes care of the rest (as long as the label is added to the UI right after).

Example usage: 
```rust
        ui.add(
            Label::new("Experimenting Example")
                .with_font(ascii::FONT_10X20)
                .with_color(Rgb565::CSS_BLUE_VIOLET),
        );
```

How this looked previously: 
```rust
            ui.sub_ui(|ui| {
                ui.style_mut().text_color = Rgb565::CSS_BLUE_VIOLET;;

                ui.add(
                    Label::new("Experimenting Example")
                        .with_font(ascii::FONT_10X20)
                );

                Ok(())
            })
                .unwrap();
```

This change is a preliminary test implementation of the idea I got sent by @ElectronicKiwi.

## TODO before this can be merged
- [ ] Update documentation
- [ ] Add breaking change to README
- [ ] Update Semantic Version (BREAKING!)