### PR TITLE
Rounded Corners for buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Kolibri - A GUI framework made to be as lightweight as its namesake
 
 ## What is Kolibri?
+
 Kolibri is an embedded Immediate Mode GUI mini-framework very strongly inspired by [egui](https://docs.rs/egui/latest/egui/).
-Kolibri is designed to be dead simple. 
+Kolibri is designed to be dead simple.
 
 ## Quick Overview
 
@@ -49,7 +50,7 @@ Those 11 Lines of code will produce this GUI:
 
 ![basic-example](./assets/basic-example.png)
 
-Yes, that's really everything. No boilerplate, no nothing. 
+Yes, that's really everything. No boilerplate, no nothing.
 If you want to see the full code using the `embedded-graphics-simulator`, look at the `basic-example.rs` file in the `examples` folder.
 (note that you need `sdl2` installed to run the simulator)
 
@@ -62,7 +63,8 @@ to run at framerates faster than the human eye can see.
 
 ![smartstate-example](./assets/incremental_redraw.png)
 
-So, how much extra code does this need? There's two things you need to do: 
+So, how much extra code does this need? There's two things you need to do:
+
 1. Initialize a `SmartstateProvider` with the number of smartstates you want to use
 2. Add a `smartstate` to each widget you want to be smartstate-reactive
 
@@ -100,8 +102,7 @@ fn main() {
 }
 ```
 
-Alternatively, use a HashLabel: 
-
+Alternatively, use a HashLabel:
 
 ```rust
 fn main() {
@@ -146,14 +147,13 @@ fn main() {
 
 ```
 
-For this hassle, you get a speedup of around 15x on an ILI9341 SPI display for the example above, 
+For this hassle, you get a speedup of around 15x on an ILI9341 SPI display for the example above,
 and over 100x for more complicated GUIs.
 
 > Note:
-> 
+>
 > This will probably be changed to be automatic in the future, which would remove the need for the `smartstate` method,
 > but also be a breaking change.
-
 
 #### Smart Buffering
 
@@ -195,17 +195,16 @@ speeds up the drawing considerably (up to 3x faster on an ILI9341 SPI display).
 Kolibri comes with a built-in theming system, which allows you to easily change the look of your GUI.
 Almost all aspects can be customized, from the colors down to the font, icon spacing, size, and more.
 
-This allows you to create themes for any `PixelColor` type (e.g. Black and White for e-ink screens), 
+This allows you to create themes for any `PixelColor` type (e.g. Black and White for e-ink screens),
 and even switch themes at runtime.
 
 ![theme-example](./assets/theming-demo-example.png)
 
 > (themes from left to right: Dark, Blue, Light, Retro)
 
-
 ### Compatible with everything
 
-Kolibri is based on the [`embedded-graphics`](https://github.com/embedded-graphics/embedded-graphics/) crate, which 
+Kolibri is based on the [`embedded-graphics`](https://github.com/embedded-graphics/embedded-graphics/) crate, which
 means that it can be used with practically any display driver for Rust.
 Kolibri's dead simple input system allows you to use any input device that can give you an `(x, y)` point on your screen,
 like touch screen drivers, or mouse pointers.
@@ -214,7 +213,8 @@ like touch screen drivers, or mouse pointers.
 > but not yet available. If you need those for a project, feel free to open an issue or a pull request.
 
 ## Current State
-Kolibri is maturing at a fast pace. Right now, it already has everything you need for a small, basic application. 
+
+Kolibri is maturing at a fast pace. Right now, it already has everything you need for a small, basic application.
 It's still in alpha, but the API is taking shape. Some breaking changes will happen, but they should be minor,
 for the most part at least.
 
@@ -233,53 +233,51 @@ if you have any questions.
 - [x] icons
 - [x] incremental rendering (only redraw what's actually needed)
 - [x] optional buffer-based rendering
-- [x] styling 
+- [x] styling
 
 #### Advanced (and granular)
 
 - [ ] layout
-    - [x] right-to-left top-to-bottom layout
-    - [ ] aligns (center, right, bottom, ...) (partially available in widgets)
-    - [x] side panels (right)
-    - [ ] side panels (all sides)
-    - [x] modals (e.g. drawing an alert box on top of everything else)
-      - somewhat done. Still needs too much manual work
-
+  - [x] right-to-left top-to-bottom layout
+  - [ ] aligns (center, right, bottom, ...) (partially available in widgets)
+  - [x] side panels (right)
+  - [ ] side panels (all sides)
+  - [x] modals (e.g. drawing an alert box on top of everything else)
+    - somewhat done. Still needs too much manual work
 
 - [ ] styling
-    - [x] Styling System
-    - [x] Premade Styles for RGB565
-    - [ ] Premade Styles for other color types
-    - [x] Sub-UIs for editing styles on the fly
+  - [x] Styling System
+  - [x] Premade Styles for RGB565
+  - [ ] Premade Styles for other color types
+  - [x] Sub-UIs for editing styles on the fly
 
 - [ ] widgets
-    - [x] Button
-    - [x] Label
-    - [x] Checkbox
-    - [x] Icon
-    - [x] Spacer
-    - [x] IconButton
-    - [ ] ListBox
-    - [ ] Something like a ScrollArea
-    - [ ] ProgressBar
-    - [x] Toggle
-    - [x] Slider
-    - [ ] Graph
+  - [x] Button
+  - [x] Label
+  - [x] Checkbox
+  - [x] Icon
+  - [x] Spacer
+  - [x] IconButton
+  - [ ] ListBox
+  - [ ] Something like a ScrollArea
+  - [ ] ProgressBar
+  - [x] Toggle
+  - [x] Slider
+  - [ ] Graph
 
 - [x] performance
-    - [x] heap-less if necessary
-    - [x] small buffer to draw everything
-    - [x] incremental redraws
+  - [x] heap-less if necessary
+  - [x] small buffer to draw everything
+  - [x] incremental redraws
 
 - [ ] input
-    - [x] generic input system (touch)
-    - [x] smartstate-reactive basic widgets
-    - [ ] virtual mouse cursor (e.g. for joystick-interaction non-touchscreens)
-    - [ ] position getter / force-interactor for e.g. encoder input
-    - [ ] custom gestures
-      - near-impossible without a kind of gesture manager struct. 
-        Probably better for a separate crate.
-
+  - [x] generic input system (touch)
+  - [x] smartstate-reactive basic widgets
+  - [ ] virtual mouse cursor (e.g. for joystick-interaction non-touchscreens)
+  - [ ] position getter / force-interactor for e.g. encoder input
+  - [ ] custom gestures
+    - near-impossible without a kind of gesture manager struct.
+      Probably better for a separate crate.
 
 - [ ] testing
   - [ ] unit tests for non-widget code
@@ -294,25 +292,24 @@ if you have any questions.
   - [ ] unit tests for Ui struct itself
   - [ ] automated integration tests (maybe Wokwi?)
 
-
 - [ ] simulator (not yet scheduled, mostly an idea for now)
   - [ ] e-g web simulator based examples
   - [ ] e-g web simulator based playground
-    - [ ] select lines to ignore (rationale: paste embedded code, ignore all lines that call to the software, 
-          and see & develop the GUI in the browser, then copy the code back to the embedded application 
-          *without deleting lines*)
+    - [ ] select lines to ignore (rationale: paste embedded code, ignore all lines that call to the software,
+      and see & develop the GUI in the browser, then copy the code back to the embedded application
+      *without deleting lines*)
     - [ ] super-fast live reload
 
 **Something missing?** Add an issue with the features you believe would be good.
 
-
 ### Expected Breaking Changes
 
-- `SmartstateProvider` might be integrated into the GUI, 
-       which would remove the need for the `smartstate` method on widgets.
+- `SmartstateProvider` might be integrated into the GUI,
+  which would remove the need for the `smartstate` method on widgets.
 - sub_ui methods (e.g. `ui.sub_ui()`, or `ui.right_panel()`) callbacks will change their signature from
   `(&mut UI) -> GuiResult<()>` to `(&mut UI) -> ()` to make Kolibri more ergonomic.
   > Expected API changes:
+  >
   > ```rust
   > // current
   > ui.sub_ui(|ui| {
@@ -327,7 +324,6 @@ if you have any questions.
   >  });
   > ```
 
-
 ## Why another GUI framework?
 
 Actually, it's in some ways the first, at least in its very, very specific niche.
@@ -336,37 +332,38 @@ library is to make creating simple to somewhat-complex GUIs trivially easy. Ther
 does this, really, at least at the time of writing this library.
 
 > #### Sidenote: What is a Kolibri?
+>
 > Kolibri is the german word for Hummingbird, which is a small bird that is very fast and agile.
 > There is also an OS with a similar name (KolibriOS), for similar reasons: It is small and fast.
 > This library is in no way associated with the [KolibriOS](https://kolibrios.org/en/) project, but
 > I do encourage you to check it out if you're interested.
 
 ### What is this not?
-Kolibri is not a high-end GUI framework. It is not meant to be used for creating 
-very complicated or super nice-looking user interfaces. If that's something you're 
-interested in, check out [the rust bindings for lvgl](https://github.com/lvgl/lv_binding_rust/) or 
-[slint (not free for commercial use)](https://slint.rs/).
 
+Kolibri is not a high-end GUI framework. It is not meant to be used for creating
+very complicated or super nice-looking user interfaces. If that's something you're
+interested in, check out [the rust bindings for lvgl](https://github.com/lvgl/lv_binding_rust/) or
+[slint (not free for commercial use)](https://slint.rs/).
 
 ## Changelog
 
 ### v0.1.0
+
 - **!BREAKING!** Renaming of `SmartstateProvider::next()` to `SmartstateProvider::nxt()`
 - Addition of toggle button / switch
 - Addition of Sliders
 - Add Subtitles to IconButtons
 
-
 ## License
 
 Licensed under either of
 
-* Apache License, Version 2.0 (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
-* MIT license (LICENSE-MIT or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 (LICENSE-APACHE or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license (LICENSE-MIT or <http://opensource.org/licenses/MIT>)
 
 at your option.
 
 ## Contribution
 
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as 
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as
 defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/src/button.rs
+++ b/src/button.rs
@@ -11,7 +11,7 @@ use embedded_graphics::geometry::{Point, Size};
 use embedded_graphics::mono_font::MonoTextStyle;
 use embedded_graphics::pixelcolor::PixelColor;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::{PrimitiveStyleBuilder, Rectangle};
+use embedded_graphics::primitives::{PrimitiveStyleBuilder, Rectangle, RoundedRectangle};
 use embedded_graphics::text::{Baseline, Text};
 
 /// # Button Widget
@@ -79,6 +79,7 @@ use embedded_graphics::text::{Baseline, Text};
 pub struct Button<'a> {
     label: &'a str,
     smartstate: Container<'a, Smartstate>,
+    corner_radius: Option<u32>,
 }
 
 impl<'a> Button<'a> {
@@ -93,6 +94,7 @@ impl<'a> Button<'a> {
         Button {
             label,
             smartstate: Container::empty(),
+            corner_radius: None,
         }
     }
 
@@ -108,6 +110,20 @@ impl<'a> Button<'a> {
     /// Self with smartstate configured
     pub fn smartstate(mut self, smartstate: &'a mut Smartstate) -> Self {
         self.smartstate.set(smartstate);
+        self
+    }
+
+    /// Sets a custom corner radius for the button.
+    ///
+    /// If not specified, the button will use the corner radius from the UI style.
+    ///
+    /// # Arguments
+    /// * `radius` - The corner radius in pixels
+    ///
+    /// # Returns
+    /// Self with the specified corner radius
+    pub fn with_radius(mut self, radius: u32) -> Self {
+        self.corner_radius = Some(radius);
         self
     }
 }
@@ -189,11 +205,13 @@ impl Widget for Button<'_> {
         if !self.smartstate.eq_option(&prevstate) {
             ui.start_drawing(&iresponse.area);
 
-            ui.draw(
-                &Rectangle::new(iresponse.area.top_left, iresponse.area.size)
-                    .into_styled(rect_style),
-            )
-            .ok();
+            let corner_radius = self.corner_radius.unwrap_or(ui.style().corner_radius);
+            let rounded_rect = RoundedRectangle::with_equal_corners(
+                Rectangle::new(iresponse.area.top_left, iresponse.area.size),
+                Size::new(corner_radius, corner_radius),
+            );
+
+            ui.draw(&rounded_rect.into_styled(rect_style)).ok();
             ui.draw(&text).ok();
 
             ui.finalize()?;

--- a/src/checkbox.rs
+++ b/src/checkbox.rs
@@ -18,7 +18,7 @@ use embedded_graphics::geometry::{Point, Size};
 use embedded_graphics::image::Image;
 use embedded_graphics::pixelcolor::PixelColor;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::{PrimitiveStyleBuilder, Rectangle};
+use embedded_graphics::primitives::{PrimitiveStyleBuilder, Rectangle, RoundedRectangle};
 use embedded_iconoir::prelude::*;
 use embedded_iconoir::{size12px, size18px, size24px, size32px};
 
@@ -74,6 +74,7 @@ use embedded_iconoir::{size12px, size18px, size24px, size32px};
 pub struct Checkbox<'a> {
     checked: &'a mut bool,
     smartstate: Container<'a, Smartstate>,
+    corner_radius: Option<u32>,
 }
 
 impl<'a> Checkbox<'a> {
@@ -81,6 +82,7 @@ impl<'a> Checkbox<'a> {
         Checkbox {
             checked,
             smartstate: Container::empty(),
+            corner_radius: None,
         }
     }
 
@@ -93,6 +95,20 @@ impl<'a> Checkbox<'a> {
     /// or when minimizing power consumption is important.
     pub fn smartstate(mut self, smartstate: &'a mut Smartstate) -> Self {
         self.smartstate.set(smartstate);
+        self
+    }
+
+    /// Sets a custom corner radius for the checkbox.
+    ///
+    /// If not specified, the checkbox will use the corner radius from the UI style.
+    ///
+    /// # Arguments
+    /// * `radius` - The corner radius in pixels
+    ///
+    /// # Returns
+    /// Self with the specified corner radius
+    pub fn with_radius(mut self, radius: u32) -> Self {
+        self.corner_radius = Some(radius);
         self
     }
 }
@@ -190,9 +206,13 @@ impl Widget for Checkbox<'_> {
 
             // draw
 
-            let rect = Rectangle::new(iresponse.area.top_left, iresponse.area.size);
+            let corner_radius = self.corner_radius.unwrap_or(ui.style().corner_radius);
+            let rounded_rect = RoundedRectangle::with_equal_corners(
+                Rectangle::new(iresponse.area.top_left, iresponse.area.size),
+                Size::new(corner_radius, corner_radius),
+            );
 
-            ui.draw(&rect.into_styled(style.build()))
+            ui.draw(&rounded_rect.into_styled(style.build()))
                 .map_err(|_| GuiError::DrawError(Some("Couldn't draw Checkbox")))?;
 
             if *self.checked {

--- a/src/helpers/keyboard.rs
+++ b/src/helpers/keyboard.rs
@@ -501,22 +501,22 @@ impl<'a> Layout<'a> {
 /// * `ui`: The `Ui` to draw to.
 /// * `layout`: The `Layout` to use for the keyboard.
 /// * `smartstates`: The `SmartstateProvider` to use for the keyboard.
-///    If `None`, no smartstates will be used.
+///   If `None`, no smartstates will be used.
 /// * `draw_num_row`: Whether the number row shall be drawn
 /// * `pad`: Whether to pad the rows so that they appear more centered (more like a "real" keyboard)
-///     padding generally looks better with lower `button_padding` and `spacing` than standard.
+///   padding generally looks better with lower `button_padding` and `spacing` than standard.
 /// * `shift`: The boolean to use for the shift state.
-///    If this changes, the returned `response.changed()` will be `true`.
+///   If this changes, the returned `response.changed()` will be `true`.
 /// * `open`: The boolean to use for the open state. If this is `false`, the keyboard will not be drawn.
-///    If this changes, the returned `response.changed()` will be `true`.
+///   If this changes, the returned `response.changed()` will be `true`.
 /// * `text`: The string to add / remove characters to / from.
-///    If this changes, the returned `response.changed()` will be `true`.
+///   If this changes, the returned `response.changed()` will be `true`.
 ///
 /// # Returns
 ///
 /// * A `Response` made from an `InternalResponse::empty()`.
-///     If a key was pressed, shift was clicked, or a key was erased, `response.changed()` will be `true`.
-///     If a key was pressed (irrelevant of changes), `response.clicked()` will be `true`.
+///   If a key was pressed, shift was clicked, or a key was erased, `response.changed()` will be `true`.
+///   If a key was pressed (irrelevant of changes), `response.clicked()` will be `true`.
 #[allow(clippy::too_many_arguments)]
 pub fn draw_keyboard<
     DRAW: DrawTarget<Color = COL>,

--- a/src/style.rs
+++ b/src/style.rs
@@ -116,7 +116,7 @@ pub fn medsize_rgb565_style() -> Style<Rgb565> {
         default_font: mono_font::iso_8859_10::FONT_9X15,
         spacing: Spacing {
             item_spacing: Size::new(8, 4),
-            button_padding: Size::new(5, 5),
+            button_padding: Size::new(6, 5),
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
         },
@@ -144,7 +144,7 @@ pub fn medsize_light_rgb565_style() -> Style<Rgb565> {
         default_font: mono_font::iso_8859_10::FONT_9X15,
         spacing: Spacing {
             item_spacing: Size::new(8, 4),
-            button_padding: Size::new(5, 5),
+            button_padding: Size::new(6, 5),
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
         },
@@ -172,7 +172,7 @@ pub fn medsize_sakura_rgb565_style() -> Style<Rgb565> {
         default_font: mono_font::ascii::FONT_9X15,
         spacing: Spacing {
             item_spacing: Size::new(8, 4),
-            button_padding: Size::new(5, 5),
+            button_padding: Size::new(6, 5),
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
         },
@@ -200,7 +200,7 @@ pub fn medsize_blue_rgb565_style() -> Style<Rgb565> {
         default_font: mono_font::iso_8859_10::FONT_9X15,
         spacing: Spacing {
             item_spacing: Size::new(8, 4),
-            button_padding: Size::new(5, 5),
+            button_padding: Size::new(6, 5),
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
         },
@@ -232,7 +232,7 @@ pub fn medsize_crt_rgb565_style() -> Style<Rgb565> {
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
         },
-        corner_radius: 8,
+        corner_radius: 0,
     }
 }
 
@@ -260,7 +260,7 @@ pub fn medsize_retro_rgb565_style() -> Style<Rgb565> {
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
         },
-        corner_radius: 8,
+        corner_radius: 0,
     }
 }
 
@@ -310,7 +310,7 @@ pub struct Style<COL: PixelColor> {
     pub border_color: COL,
     /// Primary accent color for interactive elements
     pub primary_color: COL,
-    /// Secondary accent color for additional highlighting
+    /// Secondary accent color for additional highlighting;
     pub secondary_color: COL,
     /// Color used for icons
     pub icon_color: COL,

--- a/src/style.rs
+++ b/src/style.rs
@@ -92,6 +92,7 @@ pub fn medsize_rgb565_debug_style() -> Style<Rgb565> {
             default_padding: Size::new(3, 3),
             window_border_padding: Size::new(3, 3),
         },
+        corner_radius: 8,
     }
 }
 
@@ -119,6 +120,7 @@ pub fn medsize_rgb565_style() -> Style<Rgb565> {
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
         },
+        corner_radius: 8,
     }
 }
 
@@ -146,6 +148,7 @@ pub fn medsize_light_rgb565_style() -> Style<Rgb565> {
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
         },
+        corner_radius: 8,
     }
 }
 
@@ -173,6 +176,7 @@ pub fn medsize_sakura_rgb565_style() -> Style<Rgb565> {
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
         },
+        corner_radius: 8,
     }
 }
 
@@ -200,6 +204,7 @@ pub fn medsize_blue_rgb565_style() -> Style<Rgb565> {
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
         },
+        corner_radius: 8,
     }
 }
 
@@ -227,6 +232,7 @@ pub fn medsize_crt_rgb565_style() -> Style<Rgb565> {
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
         },
+        corner_radius: 8,
     }
 }
 
@@ -254,6 +260,7 @@ pub fn medsize_retro_rgb565_style() -> Style<Rgb565> {
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
         },
+        corner_radius: 8,
     }
 }
 
@@ -292,6 +299,7 @@ pub fn medsize_retro_rgb565_style() -> Style<Rgb565> {
 ///     highlight_border_width: 2,
 ///     highlight_item_background_color: Rgb565::BLUE,
 ///     item_background_color: Rgb565::BLACK,
+///     corner_radius: 8,
 /// };
 /// ```
 #[derive(Debug, Clone, Copy)]
@@ -324,4 +332,6 @@ pub struct Style<COL: PixelColor> {
     pub highlight_border_width: u32,
     /// Color used for text
     pub text_color: COL,
+    /// Corner radius for rounded corners on widgets
+    pub corner_radius: u32,
 }

--- a/src/toggle_button.rs
+++ b/src/toggle_button.rs
@@ -17,7 +17,7 @@ use embedded_graphics::geometry::{Point, Size};
 use embedded_graphics::mono_font::MonoTextStyle;
 use embedded_graphics::pixelcolor::PixelColor;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::{PrimitiveStyleBuilder, Rectangle};
+use embedded_graphics::primitives::{PrimitiveStyleBuilder, Rectangle, RoundedRectangle};
 use embedded_graphics::text::{Baseline, Text};
 
 /// A button widget that can be toggled on and off.
@@ -55,6 +55,7 @@ pub struct ToggleButton<'a> {
     label: &'a str,
     active: &'a mut bool,
     smartstate: Container<'a, Smartstate>,
+    corner_radius: Option<u32>,
 }
 
 impl<'a> ToggleButton<'a> {
@@ -101,6 +102,7 @@ impl<'a> ToggleButton<'a> {
             label,
             active,
             smartstate: Container::empty(),
+            corner_radius: None,
         }
     }
 
@@ -112,6 +114,20 @@ impl<'a> ToggleButton<'a> {
     /// Returns self for method chaining.
     pub fn smartstate(mut self, smartstate: &'a mut Smartstate) -> Self {
         self.smartstate.set(smartstate);
+        self
+    }
+
+    /// Sets a custom corner radius for the toggle button.
+    ///
+    /// If not specified, the button will use the corner radius from the UI style.
+    ///
+    /// # Arguments
+    /// * `radius` - The corner radius in pixels
+    ///
+    /// # Returns
+    /// Self with the specified corner radius
+    pub fn with_radius(mut self, radius: u32) -> Self {
+        self.corner_radius = Some(radius);
         self
     }
 }
@@ -223,8 +239,12 @@ impl Widget for ToggleButton<'_> {
         if redraw {
             ui.start_drawing(&iresponse.area);
 
-            let rect = Rectangle::new(iresponse.area.top_left, iresponse.area.size);
-            ui.draw(&rect.into_styled(style))
+            let corner_radius = self.corner_radius.unwrap_or(ui.style().corner_radius);
+            let rounded_rect = RoundedRectangle::with_equal_corners(
+                Rectangle::new(iresponse.area.top_left, iresponse.area.size),
+                Size::new(corner_radius, corner_radius),
+            );
+            ui.draw(&rounded_rect.into_styled(style))
                 .map_err(|_| GuiError::DrawError(Some("Couldn't draw ToggleButton")))?;
             ui.draw(&text)
                 .map_err(|_| GuiError::DrawError(Some("Couldn't draw ToggleButton label")))?;


### PR DESCRIPTION
This PR introduces rounded corners. To accomplish that, it switches the `embedded_graphics` `Rect` used in rendering to a `RoundedRect`. 
It also introduces a `corner_radius` prop to the `Style`. Note that this is a breaking change for existing styles, as this property needs to be added!

BREAKING_CHANGE: styles now need corner_radius property


### Button updates
* Added a `corner_radius` field to the `Button`, `IconButton`, and `ToggleButton` structs, allowing optional customization of corner radii. [[1]](diffhunk://#diff-c52f0b171d182ec9fb14cfef910a23fd3dc521250471e3b19032b2e2b04302c9R82) [[2]](diffhunk://#diff-dcebf50a775ee6103fd052c2af4e6971aacd6c6a3fd97b379b9987163a373d95R84) [[3]](diffhunk://#diff-b7d8d257e264ba7057c2fb37d6e9c25c4d18492bb9dc42311d0da6a0b864f02cR58)
* Introduced `with_radius` methods in each widget's implementation to set custom corner radii. [[1]](diffhunk://#diff-c52f0b171d182ec9fb14cfef910a23fd3dc521250471e3b19032b2e2b04302c9R115-R128) [[2]](diffhunk://#diff-dcebf50a775ee6103fd052c2af4e6971aacd6c6a3fd97b379b9987163a373d95R227-R240) [[3]](diffhunk://#diff-b7d8d257e264ba7057c2fb37d6e9c25c4d18492bb9dc42311d0da6a0b864f02cR119-R132)
* Updated the rendering logic to use `RoundedRectangle` instead of `Rectangle`, applying the specified or default corner radius. [[1]](diffhunk://#diff-c52f0b171d182ec9fb14cfef910a23fd3dc521250471e3b19032b2e2b04302c9L192-R214) [[2]](diffhunk://#diff-dcebf50a775ee6103fd052c2af4e6971aacd6c6a3fd97b379b9987163a373d95L359-R382) [[3]](diffhunk://#diff-b7d8d257e264ba7057c2fb37d6e9c25c4d18492bb9dc42311d0da6a0b864f02cL226-R247)

### Style Updates
* Added a `corner_radius` field to the `Style` struct to define default corner radii for widgets.
* Updated various predefined styles (`medsize_rgb565_debug_style`, `medsize_rgb565_style`, etc.) to include a default corner radius of 8 pixels. [[1]](diffhunk://#diff-5452dc5fb15e73154c0ecc33e87a14379a97f817fe0cdb0fb9d17df712feb8fbR95) [[2]](diffhunk://#diff-5452dc5fb15e73154c0ecc33e87a14379a97f817fe0cdb0fb9d17df712feb8fbR123) [[3]](diffhunk://#diff-5452dc5fb15e73154c0ecc33e87a14379a97f817fe0cdb0fb9d17df712feb8fbR151) [[4]](diffhunk://#diff-5452dc5fb15e73154c0ecc33e87a14379a97f817fe0cdb0fb9d17df712feb8fbR179) [[5]](diffhunk://#diff-5452dc5fb15e73154c0ecc33e87a14379a97f817fe0cdb0fb9d17df712feb8fbR207) [[6]](diffhunk://#diff-5452dc5fb15e73154c0ecc33e87a14379a97f817fe0cdb0fb9d17df712feb8fbR235) [[7]](diffhunk://#diff-5452dc5fb15e73154c0ecc33e87a14379a97f817fe0cdb0fb9d17df712feb8fbR263)