### PR TITLE
Add decoration to Label, HashLabel and Icon. Breaking change to Widget trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 .aider*
 .env
+SDL2.dll
+SDL2.lib

--- a/examples/experimenting.rs
+++ b/examples/experimenting.rs
@@ -1,6 +1,7 @@
 use embedded_graphics::geometry::Size;
 use embedded_graphics::pixelcolor::Rgb565;
-use embedded_graphics::prelude::Point;
+use embedded_graphics::prelude::{Point, WebColors};
+use embedded_graphics::text::DecorationColor;
 use embedded_graphics_simulator::sdl2::MouseButton;
 use embedded_graphics_simulator::{
     OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
@@ -9,7 +10,7 @@ use kolibri_embedded_gui::button::Button;
 use kolibri_embedded_gui::icon::IconWidget;
 use kolibri_embedded_gui::iconbutton::IconButton;
 use kolibri_embedded_gui::icons::size24px;
-use kolibri_embedded_gui::label::{HashLabel, Hasher};
+use kolibri_embedded_gui::label::{HashLabel, Hasher, Label};
 use kolibri_embedded_gui::slider::Slider;
 use kolibri_embedded_gui::smartstate::SmartstateProvider;
 use kolibri_embedded_gui::style::*;
@@ -90,7 +91,11 @@ fn main() -> Result<(), core::convert::Infallible> {
 
         ui.expand_row_height(20);
         ui.add_horizontal(Button::new("Another button!").smartstate(smartstates.nxt()));
-        ui.add(IconWidget::<size24px::layout::CornerBottomLeft>::new_from_type());
+        ui.add_horizontal(IconWidget::<size24px::layout::CornerBottomLeft, Rgb565>::new_from_type());
+        ui.add(IconWidget::<size24px::layout::CornerBottomLeft, Rgb565>::new_from_type()
+            .with_color(Rgb565::CSS_RED)
+            .with_background_color(Rgb565::CSS_DARK_GREEN)
+        );
         // ui.add(IconButton::new(size24px::actions::AddCircle));
         ui.add_horizontal(IconButton::new(size24px::actions::AddCircle).label("Add 2"));
         ui.add_horizontal(IconButton::new(size24px::actions::AddCircle).label("Add 2"));
@@ -108,9 +113,18 @@ fn main() -> Result<(), core::convert::Infallible> {
             println!("Slider value: {}", slider_val);
         }
 
-        ui.add(ToggleButton::new("Something", &mut state).smartstate(smartstates.nxt()));
+        ui.add_horizontal(ToggleButton::new("Something", &mut state).smartstate(smartstates.nxt()));
         ui.add(ToggleSwitch::new(&mut state).smartstate(smartstates.nxt()));
 
+        ui.add_horizontal(Label::new("Decorated")
+            .with_color(Rgb565::CSS_BLUE)
+            .with_underline(DecorationColor::Custom(Rgb565::CSS_RED))
+        );
+        ui.add(Label::new("Label")
+            .with_color(Rgb565::CSS_BLACK)
+            .with_strikethrough(DecorationColor::TextColor)
+            .with_background_color(Rgb565::CSS_YELLOW)
+        );
         /*
         ui.right_panel_ui(200, true, |ui| {
             ui.add(Label::new("Right panel").smartstate(smartstates.next()));

--- a/examples/keyboard.rs
+++ b/examples/keyboard.rs
@@ -86,7 +86,7 @@ fn main() -> Result<(), core::convert::Infallible> {
         {
             open = true;
         };
-        ui.add(IconWidget::<size24px::layout::CornerBottomLeft>::new_from_type());
+        ui.add(IconWidget::<size24px::layout::CornerBottomLeft,Rgb565>::new_from_type());
 
         // ui.add(Keyboard::new(Layout::qwerty(), &mut None, &mut false));
 

--- a/examples/motion-scheduler.rs
+++ b/examples/motion-scheduler.rs
@@ -60,8 +60,8 @@ enum ButtonPress {
     Center,
 }
 
-impl Widget for StepWidget<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for StepWidget<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/examples/theming.rs
+++ b/examples/theming.rs
@@ -81,7 +81,7 @@ fn main() -> Result<(), core::convert::Infallible> {
 
         // add button first to center icon vertically
         ui.add_horizontal(IconButton::new(size24px::navigation::ArrowUpCircle));
-        ui.add(IconWidget::<size24px::actions::RefreshDouble>::new_from_type());
+        ui.add(IconWidget::<size24px::actions::RefreshDouble, Rgb565>::new_from_type());
 
         // one row offset
         ui.new_row();

--- a/src/button.rs
+++ b/src/button.rs
@@ -112,8 +112,8 @@ impl<'a> Button<'a> {
     }
 }
 
-impl Widget for Button<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Button<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/checkbox.rs
+++ b/src/checkbox.rs
@@ -124,8 +124,8 @@ impl Checkbox<'_> {
     }
 }
 
-impl Widget for Checkbox<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Checkbox<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/iconbutton.rs
+++ b/src/iconbutton.rs
@@ -223,7 +223,7 @@ impl<'a, ICON: IconoirIcon> IconButton<'a, ICON> {
     }
 }
 
-impl<ICON: IconoirIcon> Widget for IconButton<'_, ICON> {
+impl<ICON: IconoirIcon, COL: PixelColor> Widget<COL> for IconButton<'_, ICON> {
     /// Draws the icon button within the UI.
     ///
     /// This method:
@@ -234,7 +234,7 @@ impl<ICON: IconoirIcon> Widget for IconButton<'_, ICON> {
     /// 5. Manages visual appearance based on interaction state
     /// 6. Updates the smartstate and draws when necessary
     /// 7. Returns a response that includes click information
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/label.rs
+++ b/src/label.rs
@@ -50,7 +50,7 @@ use embedded_graphics::mono_font::MonoFont;
 use embedded_graphics::mono_font::MonoTextStyle;
 use embedded_graphics::pixelcolor::PixelColor;
 use embedded_graphics::prelude::*;
-use embedded_graphics::text::{Baseline, Text};
+use embedded_graphics::text::{Baseline, DecorationColor, Text};
 use foldhash::fast::RandomState;
 
 /// A widget for displaying text in the UI.
@@ -92,13 +92,17 @@ use foldhash::fast::RandomState;
 /// // Label with custom font and smartstate
 /// ui.add(Label::new("Custom font").with_font(ascii::FONT_10X20).smartstate(smartstateProvider.nxt()));
 /// ```
-pub struct Label<'a> {
+pub struct Label<'a, COL: PixelColor> {
     text: &'a str,
     font: Option<MonoFont<'a>>,
     smartstate: Container<'a, Smartstate>,
+    foreground_color: Option<COL>,
+    background_color: Option<COL>,
+    underline: DecorationColor<COL>,
+    strikethrough: DecorationColor<COL>,
 }
 
-impl<'a> Label<'a> {
+impl<'a, COL: PixelColor> Label<'a, COL> {
     /// Creates a new label with the given text.
     ///
     /// # Examples
@@ -123,11 +127,15 @@ impl<'a> Label<'a> {
     /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
     /// ui.add(Label::new("Hello World"));
     /// ```
-    pub fn new(text: &'a str) -> Label<'a> {
+    pub fn new(text: &'a str) -> Label<'a, COL> {
         Label {
             text,
             font: None,
             smartstate: Container::empty(),
+            foreground_color: None,
+            background_color: None,
+            underline: DecorationColor::None,
+            strikethrough: DecorationColor::None,
         }
     }
 
@@ -195,10 +203,136 @@ impl<'a> Label<'a> {
         self.smartstate.set(smartstate);
         self
     }
+
+    /// Sets a custom text color for the label.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Text Color").with_color(Rgb565::CSS_BLUE));
+    /// ```
+    pub fn with_color(mut self, color: COL) -> Self {
+        self.foreground_color = Some(color);
+        self
+    }
+
+    /// Sets a custom background color for the label.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Background Color").with_background_color(Rgb565::CSS_YELLOW));
+    /// ```
+    pub fn with_background_color(mut self, color: COL) -> Self {
+        self.background_color = Some(color);
+        self
+    }
+
+    /// Sets underline for the label using DecorationColor
+    /// DecorationColor::None - no underline drawn
+    /// DecorationColor::TextColor - underline drawn in same color as text label
+    /// DecorationColor::Custom(COL:PixelColor) - underline drawin in given color
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Text Color").with_underline(DecorationColor::Custom(Rgb565::CSS_BLUE));
+    /// ```
+    pub fn with_underline(mut self, decoration: DecorationColor<COL>) -> Self {
+        self.underline = decoration;
+        self
+    }
+
+    /// Sets strikethrough for the label using DecorationColor
+    /// DecorationColor::None - no strikethrough drawn
+    /// DecorationColor::TextColor - strikethrough drawn in same color as text label
+    /// DecorationColor::Custom(COL:PixelColor) - strikethrough drawin in given color
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Text Color").with_strikethrough(DecorationColor::Custom(Rgb565::CSS_BLUE));
+    /// ```
+    pub fn with_strikethrough(mut self, decoration: DecorationColor<COL>) -> Self {
+        self.strikethrough = decoration;
+        self
+    }
 }
 
-impl Widget for Label<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Label<'_, COL> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {
@@ -210,11 +344,19 @@ impl Widget for Label<'_> {
             ui.style().default_font
         };
 
-        let mut text = Text::new(
-            self.text,
-            Point::new(0, 0),
-            MonoTextStyle::new(&font, ui.style().text_color),
+        let mut char_style = MonoTextStyle::new(
+            &font,
+            self.foreground_color
+                .unwrap_or_else(|| ui.style().text_color),
         );
+        char_style.underline_color = self.underline;
+        char_style.strikethrough_color = self.strikethrough;
+
+        if self.background_color.is_some() {
+            char_style.background_color = self.background_color;
+        }
+
+        let mut text = Text::new(self.text, Point::new(0, 0), char_style);
 
         let size = text.bounding_box();
 
@@ -323,14 +465,18 @@ impl Default for Hasher {
 ///     &hasher
 /// ));
 /// ```
-pub struct HashLabel<'a> {
+pub struct HashLabel<'a, COL: PixelColor> {
     text: &'a str,
     font: Option<MonoFont<'a>>,
     smartstate: Container<'a, Smartstate>,
     hasher: &'a Hasher,
+    foreground_color: Option<COL>,
+    background_color: Option<COL>,
+    underline: DecorationColor<COL>,
+    strikethrough: DecorationColor<COL>,
 }
 
-impl<'a> HashLabel<'a> {
+impl<'a, COL: PixelColor> HashLabel<'a, COL> {
     /// Creates a new HashLabel with the given text, smartstate, and hasher.
     ///
     /// # Examples
@@ -370,6 +516,10 @@ impl<'a> HashLabel<'a> {
             font: None,
             smartstate: Container::new(smartstate),
             hasher,
+            foreground_color: None,
+            background_color: None,
+            underline: DecorationColor::None,
+            strikethrough: DecorationColor::None,
         }
     }
 
@@ -405,10 +555,135 @@ impl<'a> HashLabel<'a> {
         self.font = Some(font);
         self
     }
+    /// Sets a custom text color for the label.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Text Color").with_color(Rgb565::CSS_BLUE));
+    /// ```
+    pub fn with_color(mut self, color: COL) -> Self {
+        self.foreground_color = Some(color);
+        self
+    }
+
+    /// Sets a custom background color for the label.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Background Color").with_background_color(Rgb565::CSS_YELLOW));
+    /// ```
+    pub fn with_background_color(mut self, color: COL) -> Self {
+        self.background_color = Some(color);
+        self
+    }
+
+    /// Sets underline for the label using DecorationColor
+    /// DecorationColor::None - no underline drawn
+    /// DecorationColor::TextColor - underline drawn in same color as text label
+    /// DecorationColor::Custom(COL:PixelColor) - underline drawin in given color
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Text Color").with_underline(DecorationColor::Custom(Rgb565::CSS_BLUE));
+    /// ```
+    pub fn with_underline(mut self, decoration: DecorationColor<COL>) -> Self {
+        self.underline = decoration;
+        self
+    }
+
+    /// Sets strikethrough for the label using DecorationColor
+    /// DecorationColor::None - no strikethrough drawn
+    /// DecorationColor::TextColor - strikethrough drawn in same color as text label
+    /// DecorationColor::Custom(COL:PixelColor) - strikethrough drawin in given color
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Text Color").with_strikethrough(DecorationColor::Custom(Rgb565::CSS_BLUE));
+    /// ```
+    pub fn with_strikethrough(mut self, decoration: DecorationColor<COL>) -> Self {
+        self.strikethrough = decoration;
+        self
+    }
 }
 
-impl Widget for HashLabel<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for HashLabel<'_, COL> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {
@@ -420,11 +695,19 @@ impl Widget for HashLabel<'_> {
             ui.style().default_font
         };
 
-        let mut text = Text::new(
-            self.text,
-            Point::new(0, 0),
-            MonoTextStyle::new(&font, ui.style().text_color),
+        let mut char_style = MonoTextStyle::new(
+            &font,
+            self.foreground_color
+                .unwrap_or_else(|| ui.style().text_color),
         );
+        char_style.underline_color = self.underline;
+        char_style.strikethrough_color = self.strikethrough;
+
+        if self.background_color.is_some() {
+            char_style.background_color = self.background_color;
+        }
+
+        let mut text = Text::new(self.text, Point::new(0, 0), char_style);
 
         let size = text.bounding_box();
 

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -192,8 +192,8 @@ impl<'a> Slider<'a> {
     }
 }
 
-impl Widget for Slider<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Slider<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/spacer.rs
+++ b/src/spacer.rs
@@ -64,8 +64,8 @@ impl Spacer {
     }
 }
 
-impl Widget for Spacer {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Spacer {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/toggle_button.rs
+++ b/src/toggle_button.rs
@@ -116,8 +116,8 @@ impl<'a> ToggleButton<'a> {
     }
 }
 
-impl Widget for ToggleButton<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for ToggleButton<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/toggle_switch.rs
+++ b/src/toggle_switch.rs
@@ -155,8 +155,8 @@ impl<'a> ToggleSwitch<'a> {
     }
 }
 
-impl Widget for ToggleSwitch<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for ToggleSwitch<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -155,8 +155,8 @@ impl Response {
     }
 }
 
-pub trait Widget {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+pub trait Widget<COL: PixelColor> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response>;
@@ -774,7 +774,11 @@ where
     /// # let mut widget = Label::new("Hi");
     /// let response = ui.add_and_clear_col_remainder(widget, true);
     /// ```
-    pub fn add_and_clear_col_remainder(&mut self, widget: impl Widget, clear: bool) -> Response {
+    pub fn add_and_clear_col_remainder(
+        &mut self,
+        widget: impl Widget<COL>,
+        clear: bool,
+    ) -> Response {
         let resp = self.add_raw(widget).unwrap_or_else(Response::from_error);
         if clear {
             self.clear_row_to_end().ok();
@@ -810,7 +814,7 @@ where
     /// # let mut widget = Label::new("Hi");
     /// let response = ui.add(widget);
     /// ```
-    pub fn add(&mut self, widget: impl Widget) -> Response {
+    pub fn add(&mut self, widget: impl Widget<COL>) -> Response {
         let resp = self.add_raw(widget).unwrap_or_else(Response::from_error);
         self.new_row();
         resp
@@ -843,7 +847,7 @@ where
     /// # let mut widget = Label::new("Hi");
     /// let response = ui.add_centered(widget);
     /// ```
-    pub fn add_centered(&mut self, widget: impl Widget) -> Response {
+    pub fn add_centered(&mut self, widget: impl Widget<COL>) -> Response {
         let align = self.placer.align;
         self.placer.align = Align(HorizontalAlign::Center, align.1);
         let resp = self.add_raw(widget).unwrap_or_else(Response::from_error);
@@ -879,7 +883,7 @@ where
     /// # let mut widget = Label::new("Hi");
     /// let response = ui.add_horizontal(widget);
     /// ```
-    pub fn add_horizontal(&mut self, widget: impl Widget) -> Response {
+    pub fn add_horizontal(&mut self, widget: impl Widget<COL>) -> Response {
         let resp = self.add_raw(widget).unwrap_or_else(Response::from_error);
         // Allocate space between widgets; ignore space errors.
         self.allocate_space_no_wrap(self.style().spacing.item_spacing)
@@ -917,7 +921,7 @@ where
     ///     Err(e) => { /* handle error */ },
     /// }
     /// ```
-    pub fn add_raw(&mut self, mut widget: impl Widget) -> GuiResult<Response> {
+    pub fn add_raw(&mut self, mut widget: impl Widget<COL>) -> GuiResult<Response> {
         let res = widget.draw(self);
         if let (Ok(res), Some(debug_color)) = (&res, self.debug_color) {
             res.internal


### PR DESCRIPTION
This PR adds a custom foreground color and background color to Label, HashLabel and Icon, and also exposes the embedded_graphics text strikethrough and underline text decorations for Label and HashLabel.

These changes require the Widget trait to be modified so it is generic over PixelColor - a breaking change for all widget implementations.  The Icon widget is also now generic over PixelColor - a breaking change for all code adding an Icon.

Allows code like 
```
        ui.add_horizontal(Label::new("Decorated")
            .with_color(Rgb565::CSS_BLUE)
            .with_underline(DecorationColor::Custom(Rgb565::CSS_RED))
        );
        ui.add(Label::new("Label")
            .with_color(Rgb565::CSS_BLACK)
            .with_strikethrough(DecorationColor::TextColor)
            .with_background_color(Rgb565::CSS_YELLOW)
        );

```
to produce output like: 
<img width="315" height="238" alt="image" src="https://github.com/user-attachments/assets/9bc0a66a-e2ea-415a-ba84-c84973e4acfc" />
