### PR TITLE
Disabled and widget style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 .aider*
 .env
+SDL2.dll
+SDL2.lib

--- a/README.md
+++ b/README.md
@@ -298,9 +298,7 @@ if you have any questions.
 - [ ] simulator (not yet scheduled, mostly an idea for now)
   - [ ] e-g web simulator based examples
   - [ ] e-g web simulator based playground
-    - [ ] select lines to ignore (rationale: paste embedded code, ignore all lines that call to the software, 
-          and see & develop the GUI in the browser, then copy the code back to the embedded application 
-          *without deleting lines*)
+    - [ ] select lines to ignore (rationale: paste embedded code, ignore all lines that call to the software, and see & develop the GUI in the browser, then copy the code back to the embedded application *without deleting lines*)
     - [ ] super-fast live reload
 
 **Something missing?** Add an issue with the features you believe would be good.
@@ -308,10 +306,8 @@ if you have any questions.
 
 ### Expected Breaking Changes
 
-- `SmartstateProvider` might be integrated into the GUI, 
-       which would remove the need for the `smartstate` method on widgets.
-- sub_ui methods (e.g. `ui.sub_ui()`, or `ui.right_panel()`) callbacks will change their signature from
-  `(&mut UI) -> GuiResult<()>` to `(&mut UI) -> ()` to make Kolibri more ergonomic.
+- `SmartstateProvider` might be integrated into the GUI, which would remove the need for the `smartstate` method on widgets.
+- sub_ui methods (e.g. `ui.sub_ui()`, or `ui.right_panel()`) callbacks will change their signature from  `(&mut UI) -> GuiResult<()>` to `(&mut UI) -> ()` to make Kolibri more ergonomic.
   > Expected API changes:
   > ```rust
   > // current

--- a/examples/experimenting.rs
+++ b/examples/experimenting.rs
@@ -1,6 +1,7 @@
 use embedded_graphics::geometry::Size;
 use embedded_graphics::pixelcolor::Rgb565;
-use embedded_graphics::prelude::Point;
+use embedded_graphics::prelude::{Point, WebColors};
+use embedded_graphics::text::DecorationColor;
 use embedded_graphics_simulator::sdl2::MouseButton;
 use embedded_graphics_simulator::{
     OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
@@ -9,7 +10,7 @@ use kolibri_embedded_gui::button::Button;
 use kolibri_embedded_gui::icon::IconWidget;
 use kolibri_embedded_gui::iconbutton::IconButton;
 use kolibri_embedded_gui::icons::size24px;
-use kolibri_embedded_gui::label::{HashLabel, Hasher};
+use kolibri_embedded_gui::label::{HashLabel, Hasher, Label};
 use kolibri_embedded_gui::slider::Slider;
 use kolibri_embedded_gui::smartstate::SmartstateProvider;
 use kolibri_embedded_gui::style::*;
@@ -90,7 +91,11 @@ fn main() -> Result<(), core::convert::Infallible> {
 
         ui.expand_row_height(20);
         ui.add_horizontal(Button::new("Another button!").smartstate(smartstates.nxt()));
-        ui.add(IconWidget::<size24px::layout::CornerBottomLeft>::new_from_type());
+        ui.add_horizontal(IconWidget::<size24px::layout::CornerBottomLeft, Rgb565>::new_from_type());
+        ui.add(IconWidget::<size24px::layout::CornerBottomLeft, Rgb565>::new_from_type()
+            .with_color(Rgb565::CSS_RED)
+            .with_background_color(Rgb565::CSS_DARK_GREEN)
+        );
         // ui.add(IconButton::new(size24px::actions::AddCircle));
         ui.add_horizontal(IconButton::new(size24px::actions::AddCircle).label("Add 2"));
         ui.add_horizontal(IconButton::new(size24px::actions::AddCircle).label("Add 2"));
@@ -108,9 +113,18 @@ fn main() -> Result<(), core::convert::Infallible> {
             println!("Slider value: {}", slider_val);
         }
 
-        ui.add(ToggleButton::new("Something", &mut state).smartstate(smartstates.nxt()));
+        ui.add_horizontal(ToggleButton::new("Something", &mut state).smartstate(smartstates.nxt()));
         ui.add(ToggleSwitch::new(&mut state).smartstate(smartstates.nxt()));
 
+        ui.add_horizontal(Label::new("Decorated")
+            .with_color(Rgb565::CSS_BLUE)
+            .with_underline(DecorationColor::Custom(Rgb565::CSS_RED))
+        );
+        ui.add(Label::new("Label")
+            .with_color(Rgb565::CSS_BLACK)
+            .with_strikethrough(DecorationColor::TextColor)
+            .with_background_color(Rgb565::CSS_YELLOW)
+        );
         /*
         ui.right_panel_ui(200, true, |ui| {
             ui.add(Label::new("Right panel").smartstate(smartstates.next()));

--- a/examples/keyboard.rs
+++ b/examples/keyboard.rs
@@ -86,7 +86,7 @@ fn main() -> Result<(), core::convert::Infallible> {
         {
             open = true;
         };
-        ui.add(IconWidget::<size24px::layout::CornerBottomLeft>::new_from_type());
+        ui.add(IconWidget::<size24px::layout::CornerBottomLeft,Rgb565>::new_from_type());
 
         // ui.add(Keyboard::new(Layout::qwerty(), &mut None, &mut false));
 

--- a/examples/motion-scheduler.rs
+++ b/examples/motion-scheduler.rs
@@ -77,7 +77,7 @@ impl<COL: PixelColor> Widget<COL> for StepWidget<'_> {
                 Text::new(
                     &format!("{}s", dur.as_secs()),
                     Point::zero(),
-                    MonoTextStyle::new(&ui.style().default_font, ui.style().text_color),
+                    MonoTextStyle::new(&ui.style().default_font, ui.style().widget.normal.foreground_color),
                 )
                 .bounding_box()
                 .size
@@ -168,9 +168,9 @@ impl<COL: PixelColor> Widget<COL> for StepWidget<'_> {
 
             let icon =
                 size18px::navigation::NavArrowUp::new(if matches!(intr, Some(ButtonPress::Up)) {
-                    ui.style().primary_color
+                    ui.style().widget.active.background_color
                 } else {
-                    ui.style().icon_color
+                    ui.style().widget.normal.foreground_color
                 });
             let top_nav = Image::new(
                 &icon,
@@ -181,9 +181,9 @@ impl<COL: PixelColor> Widget<COL> for StepWidget<'_> {
             ui.draw(&top_nav)?;
 
             let col = if matches!(intr, Some(ButtonPress::Center)) {
-                ui.style().primary_color
+                ui.style().widget.active.background_color
             } else {
-                ui.style().icon_color
+                ui.style().widget.normal.foreground_color
             };
             let pos = iresponse.area.top_left
                 + Point::new(
@@ -258,9 +258,9 @@ impl<COL: PixelColor> Widget<COL> for StepWidget<'_> {
             ui.draw(&Image::new(
                 &size18px::navigation::NavArrowDown::new(
                     if matches!(intr, Some(ButtonPress::Down)) {
-                        ui.style().primary_color
+                        ui.style().widget.active.background_color
                     } else {
-                        ui.style().icon_color
+                        ui.style().widget.normal.foreground_color
                     },
                 ),
                 iresponse.area.top_left

--- a/examples/motion-scheduler.rs
+++ b/examples/motion-scheduler.rs
@@ -60,8 +60,8 @@ enum ButtonPress {
     Center,
 }
 
-impl Widget for StepWidget<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for StepWidget<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/examples/theming.rs
+++ b/examples/theming.rs
@@ -81,7 +81,7 @@ fn main() -> Result<(), core::convert::Infallible> {
 
         // add button first to center icon vertically
         ui.add_horizontal(IconButton::new(size24px::navigation::ArrowUpCircle));
-        ui.add(IconWidget::<size24px::actions::RefreshDouble>::new_from_type());
+        ui.add(IconWidget::<size24px::actions::RefreshDouble, Rgb565>::new_from_type());
 
         // one row offset
         ui.new_row();

--- a/src/button.rs
+++ b/src/button.rs
@@ -3,6 +3,7 @@
 //! See [Button] for more info.
 
 use crate::smartstate::{Container, Smartstate};
+use crate::style::WidgetStyle;
 use crate::ui::{GuiResult, Interaction, Response, Ui, Widget};
 use core::cmp::max;
 use core::ops::Add;
@@ -24,7 +25,7 @@ use embedded_graphics::text::{Baseline, Text};
 ///
 /// # Features
 /// - Text label with customizable font and colors
-/// - Visual feedback for different interaction states (normal, hover, pressed)
+/// - Visual feedback for different interaction states (normal, hover, pressed, disabled)
 /// - Optional smartstate support for incremental redrawing
 /// - Automatic sizing based on text content and style settings
 ///
@@ -65,23 +66,26 @@ use embedded_graphics::text::{Baseline, Text};
 /// ```
 ///
 /// # Visual States
-/// Buttons have three visual states that provide user feedback:
+/// Buttons have four visual states that provide user feedback:
 /// 1. Normal - Default appearance with standard border and background
 /// 2. Hover - Enhanced appearance when mouse/pointer is over the button
 /// 3. Pressed - Highlighted appearance when clicked/pressed
+/// 4. Disabled - diminished appearance when disabled
 ///
 /// # Styling
 /// Buttons follow the [UI]'s current style settings including:
-/// - Border colors and widths (normal and highlighted)
-/// - Background colors (normal, highlighted, and pressed)
-/// - Text color and font
-/// - Padding and spacing
-pub struct Button<'a> {
+/// - Padding, spacing and font from style
+/// - Border color, border width, text color and background color from style.widget
+/// - An optional custom widget style may be provided to override the defaults
+pub struct Button<'a, COL: PixelColor> {
     label: &'a str,
     smartstate: Container<'a, Smartstate>,
+    is_enabled: bool,
+    is_modified: bool,
+    custom_style: Option<WidgetStyle<COL>>,
 }
 
-impl<'a> Button<'a> {
+impl<'a, COL: PixelColor> Button<'a, COL> {
     /// Creates a new button with the given text label.
     ///
     /// # Arguments
@@ -89,10 +93,13 @@ impl<'a> Button<'a> {
     ///
     /// # Returns
     /// A new Button instance with the specified label and no smartstate
-    pub fn new(label: &'a str) -> Button<'a> {
+    pub fn new(label: &'a str) -> Button<'a, COL> {
         Button {
             label,
             smartstate: Container::empty(),
+            is_enabled: true,
+            is_modified: false,
+            custom_style: None,
         }
     }
 
@@ -110,9 +117,35 @@ impl<'a> Button<'a> {
         self.smartstate.set(smartstate);
         self
     }
+
+    /// Enables or disables the widget - will not respond to interaction
+    ///
+    /// # Arguments
+    /// * `enabled` - if the widget should be enabled (true) or disabled(false)
+    ///
+    /// # Returns
+    /// Self with is_enabled set
+    pub fn enable(mut self, enabled: &bool) -> Self {
+        self.is_modified = true;
+        self.is_enabled = *enabled;
+        self
+    }
+
+    /// Specifies the context for the widget to determine how it is styled
+    ///
+    /// # Arguments
+    /// * `context` - Context::Normal, Context::Primary, Context::Secondary
+    ///
+    /// # Returns
+    /// Self with context set
+    pub fn with_widget_style(mut self, style: WidgetStyle<COL>) -> Self {
+        self.is_modified = true;
+        self.custom_style = Some(style);
+        self
+    }
 }
 
-impl<COL: PixelColor> Widget<COL> for Button<'_> {
+impl<COL: PixelColor> Widget<COL> for Button<'_, COL> {
     fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
@@ -120,16 +153,18 @@ impl<COL: PixelColor> Widget<COL> for Button<'_> {
         // get size
         let font = ui.style().default_font;
 
+        let widget_style = self.custom_style.unwrap_or_else(|| ui.style().widget);
+
         let mut text = Text::new(
             self.label,
             Point::new(0, 0),
-            MonoTextStyle::new(&font, ui.style().text_color),
+            MonoTextStyle::new(&font, widget_style.normal.foreground_color),
         );
 
         let height = ui.style().default_widget_height;
         let size = text.bounding_box();
         let padding = ui.style().spacing.button_padding;
-        let border = ui.style().border_width;
+        let border = widget_style.normal.border_width;
 
         // allocate space
         let iresponse = ui.allocate_space(Size::new(
@@ -154,39 +189,54 @@ impl<COL: PixelColor> Widget<COL> for Button<'_> {
 
         // styles and smartstate
         let prevstate = self.smartstate.clone_inner();
+        let rect_style: embedded_graphics::primitives::PrimitiveStyle<COL>;
 
-        let rect_style = match iresponse.interaction {
-            Interaction::None => {
-                self.smartstate.modify(|st| *st = Smartstate::state(1));
+        if self.is_enabled {
+            rect_style = match iresponse.interaction {
+                Interaction::None => {
+                    self.smartstate.modify(|st| *st = Smartstate::state(1));
 
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(ui.style().border_color)
-                    .stroke_width(ui.style().border_width)
-                    .fill_color(ui.style().item_background_color)
-                    .build()
-            }
-            Interaction::Hover(_) => {
-                self.smartstate.modify(|st| *st = Smartstate::state(2));
+                    PrimitiveStyleBuilder::new()
+                        .stroke_color(widget_style.normal.border_color)
+                        .stroke_width(widget_style.normal.border_width)
+                        .fill_color(widget_style.normal.background_color)
+                        .build()
+                }
+                Interaction::Hover(_) => {
+                    self.smartstate.modify(|st| *st = Smartstate::state(2));
 
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(ui.style().highlight_border_color)
-                    .stroke_width(ui.style().highlight_border_width)
-                    .fill_color(ui.style().highlight_item_background_color)
-                    .build()
-            }
+                    PrimitiveStyleBuilder::new()
+                        .stroke_color(widget_style.hover.border_color)
+                        .stroke_width(widget_style.hover.border_width)
+                        .fill_color(widget_style.hover.background_color)
+                        .build()
+                }
 
-            _ => {
-                self.smartstate.modify(|st| *st = Smartstate::state(3));
+                _ => {
+                    self.smartstate.modify(|st| *st = Smartstate::state(3));
 
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(ui.style().highlight_border_color)
-                    .stroke_width(ui.style().highlight_border_width)
-                    .fill_color(ui.style().primary_color)
-                    .build()
-            }
-        };
+                    PrimitiveStyleBuilder::new()
+                        .stroke_color(widget_style.active.border_color)
+                        .stroke_width(widget_style.active.border_width)
+                        .fill_color(widget_style.active.background_color)
+                        .build()
+                }
+            };
+            text.character_style.text_color = match iresponse.interaction {
+                Interaction::None => Some(widget_style.normal.foreground_color),
+                Interaction::Hover(_) => Some(widget_style.hover.foreground_color),
 
-        if !self.smartstate.eq_option(&prevstate) {
+                _ => Some(widget_style.active.foreground_color),
+            };
+        } else {
+            rect_style = PrimitiveStyleBuilder::new()
+                .stroke_color(widget_style.disabled.border_color)
+                .stroke_width(widget_style.disabled.border_width)
+                .fill_color(widget_style.disabled.background_color)
+                .build();
+            text.character_style.text_color = Some(widget_style.disabled.foreground_color);
+        }
+        if !self.smartstate.eq_option(&prevstate) || self.is_modified {
             ui.start_drawing(&iresponse.area);
 
             ui.draw(
@@ -198,7 +248,12 @@ impl<COL: PixelColor> Widget<COL> for Button<'_> {
 
             ui.finalize()?;
         }
+        self.is_modified = false;
 
-        Ok(Response::new(iresponse).set_clicked(click).set_down(down))
+        if self.is_enabled {
+            Ok(Response::new(iresponse).set_clicked(click).set_down(down))
+        } else {
+            Ok(Response::new(iresponse).set_clicked(false).set_down(false))
+        }
     }
 }

--- a/src/button.rs
+++ b/src/button.rs
@@ -112,8 +112,8 @@ impl<'a> Button<'a> {
     }
 }
 
-impl Widget for Button<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Button<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/checkbox.rs
+++ b/src/checkbox.rs
@@ -124,8 +124,8 @@ impl Checkbox<'_> {
     }
 }
 
-impl Widget for Checkbox<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Checkbox<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/helpers/keyboard.rs
+++ b/src/helpers/keyboard.rs
@@ -501,22 +501,22 @@ impl<'a> Layout<'a> {
 /// * `ui`: The `Ui` to draw to.
 /// * `layout`: The `Layout` to use for the keyboard.
 /// * `smartstates`: The `SmartstateProvider` to use for the keyboard.
-///    If `None`, no smartstates will be used.
+/// If `None`, no smartstates will be used.
 /// * `draw_num_row`: Whether the number row shall be drawn
 /// * `pad`: Whether to pad the rows so that they appear more centered (more like a "real" keyboard)
-///     padding generally looks better with lower `button_padding` and `spacing` than standard.
+///  padding generally looks better with lower `button_padding` and `spacing` than standard.
 /// * `shift`: The boolean to use for the shift state.
-///    If this changes, the returned `response.changed()` will be `true`.
+///  If this changes, the returned `response.changed()` will be `true`.
 /// * `open`: The boolean to use for the open state. If this is `false`, the keyboard will not be drawn.
-///    If this changes, the returned `response.changed()` will be `true`.
+///  If this changes, the returned `response.changed()` will be `true`.
 /// * `text`: The string to add / remove characters to / from.
-///    If this changes, the returned `response.changed()` will be `true`.
+///  If this changes, the returned `response.changed()` will be `true`.
 ///
 /// # Returns
 ///
 /// * A `Response` made from an `InternalResponse::empty()`.
-///     If a key was pressed, shift was clicked, or a key was erased, `response.changed()` will be `true`.
-///     If a key was pressed (irrelevant of changes), `response.clicked()` will be `true`.
+///  If a key was pressed, shift was clicked, or a key was erased, `response.changed()` will be `true`.
+///  If a key was pressed (irrelevant of changes), `response.clicked()` will be `true`.
 #[allow(clippy::too_many_arguments)]
 pub fn draw_keyboard<
     DRAW: DrawTarget<Color = COL>,

--- a/src/helpers/keyboard.rs
+++ b/src/helpers/keyboard.rs
@@ -632,7 +632,7 @@ pub fn draw_keyboard<
         }
     }
     if ui
-        .add(IconButton::<size16px::navigation::NavArrowLeft>::new_from_type())
+        .add(IconButton::<size16px::navigation::NavArrowLeft, COL>::new_from_type())
         .clicked()
     {
         clicked = true;
@@ -711,12 +711,13 @@ pub fn draw_keyboard<
 
     ui.sub_ui(|ui| {
         if *shift {
-            ui.style_mut().item_background_color = ui.style().primary_color;
+            ui.style_mut().widget.normal.background_color =
+                ui.style().widget.active.background_color;
         }
 
         if ui
             .add({
-                let b = IconButton::<size16px::navigation::NavArrowUp>::new_from_type();
+                let b = IconButton::<size16px::navigation::NavArrowUp, COL>::new_from_type();
                 if let Some(smartstates) = smartstates.as_mut() {
                     b.smartstate(smartstates.nxt())
                 } else {
@@ -772,7 +773,7 @@ pub fn draw_keyboard<
 
     if ui
         .add({
-            let b = IconButton::<size16px::navigation::NavArrowDown>::new_from_type();
+            let b = IconButton::<size16px::navigation::NavArrowDown, COL>::new_from_type();
             if let Some(smartstates) = smartstates.as_mut() {
                 b.smartstate(smartstates.nxt())
             } else {

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -116,7 +116,7 @@ impl<'a, Ico: IconoirIcon, COL: PixelColor> IconWidget<'a, Ico, COL> {
         self.smartstate.set(smartstate);
         self
     }
-    
+
     /// Specifies a custom icon color
     pub fn with_color(mut self, col: COL) -> Self {
         self.foreground_color = Some(col);
@@ -127,7 +127,8 @@ impl<'a, Ico: IconoirIcon, COL: PixelColor> IconWidget<'a, Ico, COL> {
     pub fn with_background_color(mut self, col: COL) -> Self {
         self.background_color = Some(col);
         self
-    }}
+    }
+}
 
 impl<Ico: IconoirIcon, COL: PixelColor> Widget<COL> for IconWidget<'_, Ico, COL> {
     /// Draws the icon within the UI.
@@ -143,7 +144,10 @@ impl<Ico: IconoirIcon, COL: PixelColor> Widget<COL> for IconWidget<'_, Ico, COL>
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {
         // find size && allocate space
-        let icon = Ico::new(self.foreground_color.unwrap_or_else(||ui.style().icon_color));
+        let icon = Ico::new(
+            self.foreground_color
+                .unwrap_or_else(|| ui.style().widget.normal.foreground_color),
+        );
         let iresponse = ui.allocate_space(icon.size())?;
 
         let prevstate = self.smartstate.clone_inner();
@@ -170,7 +174,8 @@ impl<Ico: IconoirIcon, COL: PixelColor> Widget<COL> for IconWidget<'_, Ico, COL>
                 let bg_style = PrimitiveStyle::<COL>::with_fill(self.background_color.unwrap());
                 let bg = Rectangle::new(iresponse.area.top_left, iresponse.area.size)
                     .into_styled(bg_style);
-                ui.draw(&bg).map_err(|_| GuiError::DrawError(Some("Couldn't draw Icon background")))?;
+                ui.draw(&bg)
+                    .map_err(|_| GuiError::DrawError(Some("Couldn't draw Icon background")))?;
             }
 
             ui.draw(&img)

--- a/src/iconbutton.rs
+++ b/src/iconbutton.rs
@@ -223,7 +223,7 @@ impl<'a, ICON: IconoirIcon> IconButton<'a, ICON> {
     }
 }
 
-impl<ICON: IconoirIcon> Widget for IconButton<'_, ICON> {
+impl<ICON: IconoirIcon, COL: PixelColor> Widget<COL> for IconButton<'_, ICON> {
     /// Draws the icon button within the UI.
     ///
     /// This method:
@@ -234,7 +234,7 @@ impl<ICON: IconoirIcon> Widget for IconButton<'_, ICON> {
     /// 5. Manages visual appearance based on interaction state
     /// 6. Updates the smartstate and draws when necessary
     /// 7. Returns a response that includes click information
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/iconbutton.rs
+++ b/src/iconbutton.rs
@@ -6,10 +6,10 @@
 //!
 //! ## Core Features
 //!
-//! - Combines icon display with button interaction (click, hover, press states)
+//! - Combines icon display with button interaction (click, hover, press, disabled states)
 //! - Optional subtitle/label text below the icon
-//! - Visual feedback via color changes for different interaction states
-//! - Integration with Kolibri's theming system
+//! - Visual feedback via color and border changes for different interaction states
+//! - Integration with Kolibri's theming system with the ability to specify a custom widget style
 //! - Support for the smartstate system for efficient redrawing
 //!
 //! ## Usage
@@ -59,6 +59,7 @@
 //! - Pressed/Active: Primary color background with highlighted border
 //!
 use crate::smartstate::{Container, Smartstate};
+use crate::style::WidgetStyle;
 use crate::ui::{GuiResult, Interaction, Response, Ui, Widget};
 use core::cmp::max;
 use core::marker::PhantomData;
@@ -68,22 +69,25 @@ use embedded_graphics::image::Image;
 use embedded_graphics::mono_font::MonoTextStyle;
 use embedded_graphics::pixelcolor::PixelColor;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::{PrimitiveStyleBuilder, Rectangle};
+use embedded_graphics::primitives::{PrimitiveStyle, PrimitiveStyleBuilder, Rectangle};
 use embedded_graphics::text::{Alignment, Baseline, Text};
 use embedded_iconoir::prelude::{IconoirIcon, IconoirNewIcon};
 
 /// A button widget that displays an icon with optional text label.
 ///
 /// [IconButton] combines the visual display of an icon with interactive button
-/// behavior. It changes appearance based on user interaction (normal, hover, pressed)
+/// behavior. It changes appearance based on user interaction (normal, hover, pressed, disabled)
 /// and can optionally display a text label underneath the icon.
-pub struct IconButton<'a, ICON: IconoirIcon> {
+pub struct IconButton<'a, ICON: IconoirIcon, COL: PixelColor> {
     icon: PhantomData<ICON>,
     label: Option<&'a str>,
     smartstate: Container<'a, Smartstate>,
+    is_enabled: bool,
+    is_modified: bool,
+    custom_style: Option<WidgetStyle<COL>>,
 }
 
-impl<'a, ICON: IconoirIcon> IconButton<'a, ICON> {
+impl<'a, ICON: IconoirIcon, COL: PixelColor> IconButton<'a, ICON, COL> {
     /// Creates a new [IconButton] from an [IconoirIcon] instance.
     ///
     /// The icon color from the icon instance will be ignored, as the widget
@@ -119,6 +123,9 @@ impl<'a, ICON: IconoirIcon> IconButton<'a, ICON> {
             icon: PhantomData,
             smartstate: Container::empty(),
             label: None,
+            is_enabled: true,
+            is_modified: false,
+            custom_style: None,
         }
     }
 
@@ -185,6 +192,9 @@ impl<'a, ICON: IconoirIcon> IconButton<'a, ICON> {
             icon: PhantomData,
             smartstate: Container::empty(),
             label: None,
+            is_enabled: true,
+            is_modified: false,
+            custom_style: None,
         }
     }
 
@@ -221,9 +231,35 @@ impl<'a, ICON: IconoirIcon> IconButton<'a, ICON> {
         self.smartstate.set(smartstate);
         self
     }
+
+    /// Enables or disables the widget - will not respond to interaction when not enabled
+    ///
+    /// # Arguments
+    /// * `enabled` - if the button should be enabled (true) or disabled(false)
+    ///
+    /// # Returns
+    /// Self with is_enabled set
+    pub fn enable(mut self, enabled: &bool) -> Self {
+        self.is_modified = true;
+        self.is_enabled = *enabled;
+        self
+    }
+
+    /// Specifies a custom widget style
+    ///
+    /// # Arguments
+    /// * `style` WidgetStyle
+    ///
+    /// # Returns
+    /// Self with custom_style set
+    pub fn with_widget_style(mut self, style: WidgetStyle<COL>) -> Self {
+        self.is_modified = true;
+        self.custom_style = Some(style);
+        self
+    }
 }
 
-impl<ICON: IconoirIcon, COL: PixelColor> Widget<COL> for IconButton<'_, ICON> {
+impl<ICON: IconoirIcon, COL: PixelColor> Widget<COL> for IconButton<'_, ICON, COL> {
     /// Draws the icon button within the UI.
     ///
     /// This method:
@@ -238,11 +274,13 @@ impl<ICON: IconoirIcon, COL: PixelColor> Widget<COL> for IconButton<'_, ICON> {
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {
+        let widget_style = self.custom_style.unwrap_or_else(|| ui.style().widget);
+        let fg_color: COL;
         // get size
-        let icon = ICON::new(ui.style().icon_color);
+        let mut icon = ICON::new(widget_style.normal.foreground_color);
 
         let padding = ui.style().spacing.button_padding;
-        let border = ui.style().border_width;
+        let border = widget_style.normal.border_width;
 
         let mut min_height = icon.bounding_box().size.height + 2 * padding.height + 2 * border;
 
@@ -254,7 +292,7 @@ impl<ICON: IconoirIcon, COL: PixelColor> Widget<COL> for IconButton<'_, ICON> {
             let mut text = Text::new(
                 label,
                 Point::new(0, 0),
-                MonoTextStyle::new(&font, ui.style().text_color),
+                MonoTextStyle::new(&font, widget_style.normal.foreground_color),
             );
             text.text_style.alignment = Alignment::Center;
             text.text_style.baseline = Baseline::Top;
@@ -298,8 +336,6 @@ impl<ICON: IconoirIcon, COL: PixelColor> Widget<COL> for IconButton<'_, ICON> {
                     / 2) as i32,
             );
 
-        let icon_img = Image::new(&icon, center_offset);
-
         // center text (if it exists)
         if let Some(text) = text.as_mut() {
             let center_offset = iresponse.area.top_left
@@ -322,38 +358,66 @@ impl<ICON: IconoirIcon, COL: PixelColor> Widget<COL> for IconButton<'_, ICON> {
 
         // styles and smartstate
         let prevstate = self.smartstate.clone_inner();
+        let rect_style: PrimitiveStyle<COL>;
 
-        let rect_style = match iresponse.interaction {
-            Interaction::None => {
-                self.smartstate.modify(|st| *st = Smartstate::state(1));
+        if self.is_enabled {
+            rect_style = match iresponse.interaction {
+                Interaction::None => {
+                    self.smartstate.modify(|st| *st = Smartstate::state(1));
 
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(ui.style().border_color)
-                    .stroke_width(ui.style().border_width)
-                    .fill_color(ui.style().item_background_color)
-                    .build()
-            }
-            Interaction::Hover(_) => {
-                self.smartstate.modify(|st| *st = Smartstate::state(2));
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(ui.style().highlight_border_color)
-                    .stroke_width(ui.style().highlight_border_width)
-                    .fill_color(ui.style().highlight_item_background_color)
-                    .build()
-            }
+                    PrimitiveStyleBuilder::new()
+                        .stroke_color(widget_style.normal.border_color)
+                        .stroke_width(widget_style.normal.border_width)
+                        .fill_color(widget_style.normal.background_color)
+                        .build()
+                }
+                Interaction::Hover(_) => {
+                    self.smartstate.modify(|st| *st = Smartstate::state(2));
+                    PrimitiveStyleBuilder::new()
+                        .stroke_color(widget_style.hover.border_color)
+                        .stroke_width(widget_style.hover.border_width)
+                        .fill_color(widget_style.hover.background_color)
+                        .build()
+                }
 
-            _ => {
-                self.smartstate.modify(|st| *st = Smartstate::state(3));
+                _ => {
+                    self.smartstate.modify(|st| *st = Smartstate::state(3));
 
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(ui.style().highlight_border_color)
-                    .stroke_width(ui.style().highlight_border_width)
-                    .fill_color(ui.style().primary_color)
-                    .build()
-            }
-        };
+                    PrimitiveStyleBuilder::new()
+                        .stroke_color(widget_style.active.border_color)
+                        .stroke_width(widget_style.active.border_width)
+                        .fill_color(widget_style.active.background_color)
+                        .build()
+                }
+            };
+            match iresponse.interaction {
+                Interaction::None => {
+                    fg_color = widget_style.normal.foreground_color;
+                }
+                Interaction::Hover(_) => {
+                    fg_color = widget_style.hover.foreground_color;
+                }
+                _ => {
+                    fg_color = widget_style.active.foreground_color;
+                }
+            };
+        } else {
+            rect_style = PrimitiveStyleBuilder::new()
+                .stroke_color(widget_style.disabled.border_color)
+                .stroke_width(widget_style.disabled.border_width)
+                .fill_color(widget_style.disabled.background_color)
+                .build();
+            fg_color = widget_style.disabled.foreground_color;
+        }
 
-        if !self.smartstate.eq_option(&prevstate) {
+        icon.set_color(fg_color);
+        let icon_img = Image::new(&icon, center_offset);
+
+        if let Some(text) = text.as_mut() {
+            text.character_style.text_color = Some(fg_color);
+        }
+
+        if !self.smartstate.eq_option(&prevstate) || self.is_modified {
             ui.start_drawing(&iresponse.area);
 
             ui.draw(
@@ -368,13 +432,18 @@ impl<ICON: IconoirIcon, COL: PixelColor> Widget<COL> for IconButton<'_, ICON> {
 
             ui.finalize()?;
         }
+        self.is_modified = false;
 
-        Ok(Response::new(iresponse).set_clicked(click).set_down(down))
+        if self.is_enabled {
+            Ok(Response::new(iresponse).set_clicked(click).set_down(down))
+        } else {
+            Ok(Response::new(iresponse).set_clicked(false).set_down(false))
+        }
     }
 }
 
 // Implement common traits for IconButton
-impl<ICON: IconoirIcon> core::fmt::Debug for IconButton<'_, ICON> {
+impl<ICON: IconoirIcon, COL: PixelColor> core::fmt::Debug for IconButton<'_, ICON, COL> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("IconButton")
             .field("type", &core::any::type_name::<ICON>())

--- a/src/label.rs
+++ b/src/label.rs
@@ -63,6 +63,8 @@ use foldhash::fast::RandomState;
 /// - Basic text display with customizable fonts
 /// - Smartstate integration for incremental redrawing
 /// - Automatic vertical centering in allocated space
+/// - optional custom colors to override default style
+/// - ability to have underline or strikethrough decoration, optionally in a custom color
 ///
 /// # Examples
 ///
@@ -264,7 +266,7 @@ impl<'a, COL: PixelColor> Label<'a, COL> {
         self
     }
 
-    /// Sets underline for the label using DecorationColor
+    /// Sets underline for the label using embedded_graphics DecorationColor
     /// DecorationColor::None - no underline drawn
     /// DecorationColor::TextColor - underline drawn in same color as text label
     /// DecorationColor::Custom(COL:PixelColor) - underline drawin in given color
@@ -297,7 +299,7 @@ impl<'a, COL: PixelColor> Label<'a, COL> {
         self
     }
 
-    /// Sets strikethrough for the label using DecorationColor
+    /// Sets strikethrough for the label using embedded_graphics DecorationColor
     /// DecorationColor::None - no strikethrough drawn
     /// DecorationColor::TextColor - strikethrough drawn in same color as text label
     /// DecorationColor::Custom(COL:PixelColor) - strikethrough drawin in given color
@@ -347,7 +349,7 @@ impl<COL: PixelColor> Widget<COL> for Label<'_, COL> {
         let mut char_style = MonoTextStyle::new(
             &font,
             self.foreground_color
-                .unwrap_or_else(|| ui.style().text_color),
+                .unwrap_or_else(|| ui.style().widget.normal.foreground_color),
         );
         char_style.underline_color = self.underline;
         char_style.strikethrough_color = self.strikethrough;
@@ -698,7 +700,7 @@ impl<COL: PixelColor> Widget<COL> for HashLabel<'_, COL> {
         let mut char_style = MonoTextStyle::new(
             &font,
             self.foreground_color
-                .unwrap_or_else(|| ui.style().text_color),
+                .unwrap_or_else(|| ui.style().widget.normal.foreground_color),
         );
         char_style.underline_color = self.underline;
         char_style.strikethrough_color = self.strikethrough;

--- a/src/label.rs
+++ b/src/label.rs
@@ -50,7 +50,7 @@ use embedded_graphics::mono_font::MonoFont;
 use embedded_graphics::mono_font::MonoTextStyle;
 use embedded_graphics::pixelcolor::PixelColor;
 use embedded_graphics::prelude::*;
-use embedded_graphics::text::{Baseline, Text};
+use embedded_graphics::text::{Baseline, DecorationColor, Text};
 use foldhash::fast::RandomState;
 
 /// A widget for displaying text in the UI.
@@ -92,13 +92,17 @@ use foldhash::fast::RandomState;
 /// // Label with custom font and smartstate
 /// ui.add(Label::new("Custom font").with_font(ascii::FONT_10X20).smartstate(smartstateProvider.nxt()));
 /// ```
-pub struct Label<'a> {
+pub struct Label<'a, COL: PixelColor> {
     text: &'a str,
     font: Option<MonoFont<'a>>,
     smartstate: Container<'a, Smartstate>,
+    foreground_color: Option<COL>,
+    background_color: Option<COL>,
+    underline: DecorationColor<COL>,
+    strikethrough: DecorationColor<COL>,
 }
 
-impl<'a> Label<'a> {
+impl<'a, COL: PixelColor> Label<'a, COL> {
     /// Creates a new label with the given text.
     ///
     /// # Examples
@@ -123,11 +127,15 @@ impl<'a> Label<'a> {
     /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
     /// ui.add(Label::new("Hello World"));
     /// ```
-    pub fn new(text: &'a str) -> Label<'a> {
+    pub fn new(text: &'a str) -> Label<'a, COL> {
         Label {
             text,
             font: None,
             smartstate: Container::empty(),
+            foreground_color: None,
+            background_color: None,
+            underline: DecorationColor::None,
+            strikethrough: DecorationColor::None,
         }
     }
 
@@ -195,10 +203,136 @@ impl<'a> Label<'a> {
         self.smartstate.set(smartstate);
         self
     }
+
+    /// Sets a custom text color for the label.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Text Color").with_color(Rgb565::CSS_BLUE));
+    /// ```
+    pub fn with_color(mut self, color: COL) -> Self {
+        self.foreground_color = Some(color);
+        self
+    }
+
+    /// Sets a custom background color for the label.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Background Color").with_background_color(Rgb565::CSS_YELLOW));
+    /// ```
+    pub fn with_background_color(mut self, color: COL) -> Self {
+        self.background_color = Some(color);
+        self
+    }
+
+    /// Sets underline for the label using DecorationColor
+    /// DecorationColor::None - no underline drawn
+    /// DecorationColor::TextColor - underline drawn in same color as text label
+    /// DecorationColor::Custom(COL:PixelColor) - underline drawin in given color
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Text Color").with_underline(DecorationColor::Custom(Rgb565::CSS_BLUE));
+    /// ```
+    pub fn with_underline(mut self, decoration: DecorationColor<COL>) -> Self {
+        self.underline = decoration;
+        self
+    }
+
+    /// Sets strikethrough for the label using DecorationColor
+    /// DecorationColor::None - no strikethrough drawn
+    /// DecorationColor::TextColor - strikethrough drawn in same color as text label
+    /// DecorationColor::Custom(COL:PixelColor) - strikethrough drawin in given color
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Text Color").with_strikethrough(DecorationColor::Custom(Rgb565::CSS_BLUE));
+    /// ```
+    pub fn with_strikethrough(mut self, decoration: DecorationColor<COL>) -> Self {
+        self.strikethrough = decoration;
+        self
+    }
 }
 
-impl Widget for Label<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Label<'_, COL> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {
@@ -210,11 +344,19 @@ impl Widget for Label<'_> {
             ui.style().default_font
         };
 
-        let mut text = Text::new(
-            self.text,
-            Point::new(0, 0),
-            MonoTextStyle::new(&font, ui.style().text_color),
+        let mut char_style = MonoTextStyle::new(
+            &font,
+            self.foreground_color
+                .unwrap_or_else(|| ui.style().text_color),
         );
+        char_style.underline_color = self.underline;
+        char_style.strikethrough_color = self.strikethrough;
+
+        if self.background_color.is_some() {
+            char_style.background_color = self.background_color;
+        }
+
+        let mut text = Text::new(self.text, Point::new(0, 0), char_style);
 
         let size = text.bounding_box();
 
@@ -323,14 +465,18 @@ impl Default for Hasher {
 ///     &hasher
 /// ));
 /// ```
-pub struct HashLabel<'a> {
+pub struct HashLabel<'a, COL: PixelColor> {
     text: &'a str,
     font: Option<MonoFont<'a>>,
     smartstate: Container<'a, Smartstate>,
     hasher: &'a Hasher,
+    foreground_color: Option<COL>,
+    background_color: Option<COL>,
+    underline: DecorationColor<COL>,
+    strikethrough: DecorationColor<COL>,
 }
 
-impl<'a> HashLabel<'a> {
+impl<'a, COL: PixelColor> HashLabel<'a, COL> {
     /// Creates a new HashLabel with the given text, smartstate, and hasher.
     ///
     /// # Examples
@@ -370,6 +516,10 @@ impl<'a> HashLabel<'a> {
             font: None,
             smartstate: Container::new(smartstate),
             hasher,
+            foreground_color: None,
+            background_color: None,
+            underline: DecorationColor::None,
+            strikethrough: DecorationColor::None,
         }
     }
 
@@ -405,10 +555,135 @@ impl<'a> HashLabel<'a> {
         self.font = Some(font);
         self
     }
+    /// Sets a custom text color for the label.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Text Color").with_color(Rgb565::CSS_BLUE));
+    /// ```
+    pub fn with_color(mut self, color: COL) -> Self {
+        self.foreground_color = Some(color);
+        self
+    }
+
+    /// Sets a custom background color for the label.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Background Color").with_background_color(Rgb565::CSS_YELLOW));
+    /// ```
+    pub fn with_background_color(mut self, color: COL) -> Self {
+        self.background_color = Some(color);
+        self
+    }
+
+    /// Sets underline for the label using DecorationColor
+    /// DecorationColor::None - no underline drawn
+    /// DecorationColor::TextColor - underline drawn in same color as text label
+    /// DecorationColor::Custom(COL:PixelColor) - underline drawin in given color
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Text Color").with_underline(DecorationColor::Custom(Rgb565::CSS_BLUE));
+    /// ```
+    pub fn with_underline(mut self, decoration: DecorationColor<COL>) -> Self {
+        self.underline = decoration;
+        self
+    }
+
+    /// Sets strikethrough for the label using DecorationColor
+    /// DecorationColor::None - no strikethrough drawn
+    /// DecorationColor::TextColor - strikethrough drawn in same color as text label
+    /// DecorationColor::Custom(COL:PixelColor) - strikethrough drawin in given color
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use embedded_graphics::pixelcolor::Rgb565;
+    /// # use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder, Window};
+    /// # use kolibri_embedded_gui::style::medsize_rgb565_style;
+    /// # use kolibri_embedded_gui::ui::Ui;
+    /// # use embedded_graphics::prelude::*;
+    /// # use embedded_graphics::primitives::Rectangle;
+    /// # use embedded_iconoir::prelude::*;
+    /// # use embedded_iconoir::size12px;
+    /// # use kolibri_embedded_gui::ui::*;
+    /// # use embedded_graphics::mono_font::ascii;
+    /// # use kolibri_embedded_gui::label::*;
+    /// # use kolibri_embedded_gui::smartstate::*;
+    /// # let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(320, 240));
+    /// # let output_settings = OutputSettingsBuilder::new().build();
+    /// # let mut window = Window::new("Kolibri Example", &output_settings);
+    /// # use kolibri_embedded_gui::label::*;
+    /// # let hasher = Hasher::new();
+    /// # let mut ui = Ui::new_fullscreen(&mut display, medsize_rgb565_style());
+    /// ui.add(Label::new("Custom Text Color").with_strikethrough(DecorationColor::Custom(Rgb565::CSS_BLUE));
+    /// ```
+    pub fn with_strikethrough(mut self, decoration: DecorationColor<COL>) -> Self {
+        self.strikethrough = decoration;
+        self
+    }
 }
 
-impl Widget for HashLabel<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for HashLabel<'_, COL> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {
@@ -420,11 +695,19 @@ impl Widget for HashLabel<'_> {
             ui.style().default_font
         };
 
-        let mut text = Text::new(
-            self.text,
-            Point::new(0, 0),
-            MonoTextStyle::new(&font, ui.style().text_color),
+        let mut char_style = MonoTextStyle::new(
+            &font,
+            self.foreground_color
+                .unwrap_or_else(|| ui.style().text_color),
         );
+        char_style.underline_color = self.underline;
+        char_style.strikethrough_color = self.strikethrough;
+
+        if self.background_color.is_some() {
+            char_style.background_color = self.background_color;
+        }
+
+        let mut text = Text::new(self.text, Point::new(0, 0), char_style);
 
         let size = text.bounding_box();
 

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -8,7 +8,7 @@
 //! - Step-based value adjustments for precise control
 //! - Optional text labels for clear identification
 //! - Customizable width to fit various layouts
-//! - Visual feedback for different interaction states (normal, hover, active)
+//! - Visual feedback for different interaction states (normal, hover, active, disabled)
 //!
 //! # Examples
 //!
@@ -71,7 +71,7 @@ use embedded_graphics::geometry::{Point, Size};
 use embedded_graphics::mono_font::MonoTextStyle;
 use embedded_graphics::pixelcolor::PixelColor;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::{Circle, Line, PrimitiveStyleBuilder};
+use embedded_graphics::primitives::{Circle, Line, PrimitiveStyle, PrimitiveStyleBuilder};
 use embedded_graphics::text::{Alignment, Baseline, Text};
 
 /// Performs linear interpolation using fixed-point arithmetic for embedded systems.
@@ -127,6 +127,8 @@ pub struct Slider<'a> {
     label: Option<&'a str>,
     width: u32,
     smartstate: Container<'a, Smartstate>,
+    is_enabled: bool,
+    is_modified: bool,
 }
 
 impl<'a> Slider<'a> {
@@ -147,6 +149,8 @@ impl<'a> Slider<'a> {
             smartstate: Container::empty(),
             label: None,
             width: 200,
+            is_enabled: true,
+            is_modified: false,
         }
     }
 
@@ -190,6 +194,19 @@ impl<'a> Slider<'a> {
         self.step_size = step_size.clamp(1, range_span as u16);
         self
     }
+
+    /// Enables or disables the widget - will not respond to interaction
+    ///
+    /// # Arguments
+    /// * `enabled` - if the widget should be enabled (true) or disabled(false)
+    ///
+    /// # Returns
+    /// Self with is_enabled set
+    pub fn enable(mut self, enabled: &bool) -> Self {
+        self.is_modified = true;
+        self.is_enabled = *enabled;
+        self
+    }
 }
 
 impl<COL: PixelColor> Widget<COL> for Slider<'_> {
@@ -216,7 +233,7 @@ impl<COL: PixelColor> Widget<COL> for Slider<'_> {
             let mut text = Text::new(
                 label,
                 Point::new(0, 0),
-                MonoTextStyle::new(&font, ui.style().text_color),
+                MonoTextStyle::new(&font, ui.style().widget.active.foreground_color),
             );
             text.text_style.alignment = Alignment::Center;
             text.text_style.baseline = Baseline::Top;
@@ -255,23 +272,45 @@ impl<COL: PixelColor> Widget<COL> for Slider<'_> {
         );
 
         let style = ui.style();
-        let line_style = PrimitiveStyleBuilder::new()
-            .stroke_color(style.border_color)
-            .stroke_width(slider_thickness)
-            .fill_color(style.primary_color)
-            .build();
-        let mut slider_knob_style = PrimitiveStyleBuilder::new()
-            .stroke_color(style.border_color)
-            .stroke_width(1.max(style.border_width))
-            .fill_color(style.background_color)
-            .build();
-        let old_slider_knob_style = PrimitiveStyleBuilder::new()
-            .stroke_color(style.background_color)
-            .stroke_width(0)
-            .fill_color(style.background_color)
-            .build();
-
-        // previous slider knob circle for clearing it
+        let line_style: PrimitiveStyle<COL>;
+        let mut slider_knob_style: PrimitiveStyle<COL>;
+        let old_slider_knob_style: PrimitiveStyle<COL>;
+        if self.is_enabled {
+            line_style = PrimitiveStyleBuilder::new()
+                .stroke_color(style.widget.normal.border_color)
+                .stroke_width(slider_thickness)
+                .fill_color(style.widget.normal.background_color)
+                .build();
+            slider_knob_style = PrimitiveStyleBuilder::new()
+                .stroke_color(style.widget.normal.border_color)
+                .stroke_width(1.max(style.widget.normal.border_width))
+                .fill_color(style.widget.normal.background_color)
+                .build();
+            old_slider_knob_style = PrimitiveStyleBuilder::new()
+                .stroke_color(style.background_color)
+                .stroke_width(0)
+                .fill_color(style.background_color)
+                .build();
+        } else {
+            line_style = PrimitiveStyleBuilder::new()
+                .stroke_color(style.widget.disabled.border_color)
+                .stroke_width(slider_thickness)
+                .fill_color(style.widget.disabled.background_color)
+                .build();
+            slider_knob_style = PrimitiveStyleBuilder::new()
+                .stroke_color(style.widget.disabled.border_color)
+                .stroke_width(1.max(style.widget.disabled.border_width))
+                .fill_color(style.widget.disabled.background_color)
+                .build();
+            /*
+            old_slider_knob_style = PrimitiveStyleBuilder::new()
+                .stroke_color(style.background_color)
+                .stroke_width(0)
+                .fill_color(style.background_color)
+                .build();
+             */
+            old_slider_knob_style = slider_knob_style;
+        }
 
         // center text (if it exists)
         if let Some(text) = text.as_mut() {
@@ -294,30 +333,33 @@ impl<COL: PixelColor> Widget<COL> for Slider<'_> {
         // find user input
         // TODO
         let old_val = *self.value;
-        match iresponse.interaction {
-            Interaction::Click(point) | Interaction::Drag(point) => {
-                let slider_val = lerp_fixed(
-                    *self.range.start(),
-                    *self.range.end(),
-                    point.x as i16 - iresponse.area.top_left.x as i16,
-                    // + (slider_knob_diameter / 2) as i16,
-                    padding.width as i16 + slider_knob_diameter as i16 / 2,
-                    width as i16 - padding.width as i16 - slider_knob_diameter as i16 / 2,
-                );
-                let range_span = (*self.range.end() - *self.range.start()).abs();
-                let step_size = self.step_size.clamp(1, range_span as u16) as i16;
-                let to_next = slider_val.rem_euclid(step_size);
-                let to_prev = step_size - to_next;
-                if to_next < to_prev {
-                    *self.value = (slider_val - to_next).max(*self.range.start());
-                } else {
-                    *self.value = (slider_val + to_prev).min(*self.range.end());
+
+        if self.is_enabled {
+            match iresponse.interaction {
+                Interaction::Click(point) | Interaction::Drag(point) => {
+                    let slider_val = lerp_fixed(
+                        *self.range.start(),
+                        *self.range.end(),
+                        point.x as i16 - iresponse.area.top_left.x as i16,
+                        // + (slider_knob_diameter / 2) as i16,
+                        padding.width as i16 + slider_knob_diameter as i16 / 2,
+                        width as i16 - padding.width as i16 - slider_knob_diameter as i16 / 2,
+                    );
+                    let range_span = (*self.range.end() - *self.range.start()).abs();
+                    let step_size = self.step_size.clamp(1, range_span as u16) as i16;
+                    let to_next = slider_val.rem_euclid(step_size);
+                    let to_prev = step_size - to_next;
+                    if to_next < to_prev {
+                        *self.value = (slider_val - to_next).max(*self.range.start());
+                    } else {
+                        *self.value = (slider_val + to_prev).min(*self.range.end());
+                    }
                 }
+                _ => {}
             }
-            _ => {}
         }
 
-        let slider_knob_pos = lerp_fixed(
+        let slider_knob_pos: i16 = lerp_fixed(
             // padding.width as i16,
             padding.width as i16 + slider_knob_diameter as i16 / 2,
             width as i16 - padding.width as i16 - slider_knob_diameter as i16 / 2,
@@ -326,7 +368,7 @@ impl<COL: PixelColor> Widget<COL> for Slider<'_> {
             *self.range.end(),
         );
 
-        let slider_knob = Circle::with_center(
+        let slider_knob: Circle = Circle::with_center(
             Point::new(
                 iresponse.area.top_left.x + slider_knob_pos as i32,
                 iresponse.area.top_left.y
@@ -337,7 +379,7 @@ impl<COL: PixelColor> Widget<COL> for Slider<'_> {
         );
 
         // old slider knob (for clearing)
-        let old_slider_knob_pos = lerp_fixed(
+        let old_slider_knob_pos: i16 = lerp_fixed(
             // padding.width as i16,
             padding.width as i16 + slider_knob_diameter as i16 / 2,
             width as i16 - padding.width as i16 - slider_knob_diameter as i16 / 2,
@@ -346,7 +388,7 @@ impl<COL: PixelColor> Widget<COL> for Slider<'_> {
             *self.range.end(),
         );
 
-        let old_slider_knob = Circle::with_center(
+        let old_slider_knob: Circle = Circle::with_center(
             Point::new(
                 iresponse.area.top_left.x + old_slider_knob_pos as i32,
                 iresponse.area.top_left.y
@@ -357,24 +399,29 @@ impl<COL: PixelColor> Widget<COL> for Slider<'_> {
         );
 
         // styles and smartstate
+        let state_val: u32;
+        if self.is_enabled {
+            let interact_val: u16 = match iresponse.interaction {
+                Interaction::Click(_) | Interaction::Drag(_) => {
+                    slider_knob_style.fill_color = Some(style.widget.active.background_color);
+                    2
+                }
+                Interaction::Hover(_) => {
+                    slider_knob_style.fill_color = Some(style.widget.hover.background_color);
+                    1
+                }
+                _ => {
+                    slider_knob_style.fill_color = Some(style.widget.normal.background_color);
+                    0
+                }
+            };
+            state_val = (*self.value as u16) as u32 | ((interact_val as u32) << 16);
+        } else {
+            slider_knob_style.fill_color = Some(style.widget.disabled.background_color);
+            state_val = *self.value as u32;
+        }
 
-        let interact_val: u16 = match iresponse.interaction {
-            Interaction::Click(_) | Interaction::Drag(_) => {
-                slider_knob_style.fill_color = Some(style.primary_color);
-                2
-            }
-            Interaction::Hover(_) => {
-                slider_knob_style.fill_color = Some(style.highlight_item_background_color);
-                1
-            }
-            _ => {
-                slider_knob_style.fill_color = Some(style.item_background_color);
-                0
-            }
-        };
-        let state_val = (*self.value as u16) as u32 | ((interact_val as u32) << 16);
-
-        if !self.smartstate.eq_inner(&Smartstate::state(state_val)) {
+        if !self.smartstate.eq_inner(&Smartstate::state(state_val)) || self.is_modified {
             ui.start_drawing(&iresponse.area);
 
             if old_slider_knob_pos != slider_knob_pos {
@@ -391,10 +438,19 @@ impl<COL: PixelColor> Widget<COL> for Slider<'_> {
             ui.finalize()?;
         }
 
-        self.smartstate
-            .modify(|s| *s = Smartstate::state(state_val));
+        if self.is_modified {
+            self.is_modified = false;
+            self.smartstate.modify(|s| *s = Smartstate::state(999));
+        } else {
+            self.smartstate
+                .modify(|s| *s = Smartstate::state(state_val));
+        }
 
-        Ok(Response::new(iresponse).set_changed(old_val != *self.value)) //.set_clicked(click).set_down(down))
+        if self.is_enabled {
+            Ok(Response::new(iresponse).set_changed(old_val != *self.value)) //.set_clicked(click).set_down(down))
+        } else {
+            Ok(Response::new(iresponse).set_changed(false))
+        }
     }
 }
 

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -192,8 +192,8 @@ impl<'a> Slider<'a> {
     }
 }
 
-impl Widget for Slider<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Slider<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/spacer.rs
+++ b/src/spacer.rs
@@ -64,8 +64,8 @@ impl Spacer {
     }
 }
 
-impl Widget for Spacer {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for Spacer {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/style.rs
+++ b/src/style.rs
@@ -51,7 +51,7 @@
 //! ```
 
 use embedded_graphics::mono_font::{self, MonoFont};
-use embedded_graphics::pixelcolor::{PixelColor, Rgb565};
+use embedded_graphics::pixelcolor::{PixelColor, Rgb565, Rgb888};
 use embedded_graphics::prelude::*;
 
 /// Controls spacing between UI elements.
@@ -67,6 +67,23 @@ pub struct Spacing {
     pub window_border_padding: Size,
 }
 
+/// WidgetStyleElements specifies custom styling for a Widget state
+#[derive(Debug, Clone, Copy)]
+pub struct WidgetStyleElements<COL: PixelColor> {
+    pub border_width: u32,
+    pub border_color: COL,
+    pub background_color: COL,
+    pub foreground_color: COL,
+}
+/// WidgetStyle specifies custom styling for widgets like buttons that have different interaction states
+#[derive(Debug, Clone, Copy)]
+pub struct WidgetStyle<COL: PixelColor> {
+    pub normal: WidgetStyleElements<COL>,
+    pub hover: WidgetStyleElements<COL>,
+    pub active: WidgetStyleElements<COL>,
+    pub disabled: WidgetStyleElements<COL>,
+}
+
 /// Debug-friendly dark theme with visible borders for development.
 ///
 /// This theme uses high-contrast colors and visible borders to make UI layout
@@ -74,23 +91,39 @@ pub struct Spacing {
 pub fn medsize_rgb565_debug_style() -> Style<Rgb565> {
     Style {
         background_color: Rgb565::BLACK,
-        item_background_color: Rgb565::CSS_GRAY,
-        highlight_item_background_color: Rgb565::new(0x1, 0x2, 0x1),
-        border_color: Rgb565::RED,
-        highlight_border_color: Rgb565::WHITE,
-        primary_color: Rgb565::CYAN,
-        secondary_color: Rgb565::YELLOW,
-        icon_color: Rgb565::WHITE,
-        text_color: Rgb565::WHITE,
         default_widget_height: 16,
-        border_width: 1,
-        highlight_border_width: 1,
         default_font: mono_font::iso_8859_10::FONT_9X15,
         spacing: Spacing {
             item_spacing: Size::new(8, 4),
             button_padding: Size::new(2, 2),
             default_padding: Size::new(3, 3),
             window_border_padding: Size::new(3, 3),
+        },
+        widget: WidgetStyle {
+            normal: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::CSS_RED,
+                background_color: Rgb565::CSS_GRAY,
+                foreground_color: Rgb565::WHITE,
+            },
+            hover: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::WHITE,
+                background_color: Rgb565::new(0x1, 0x2, 0x1),
+                foreground_color: Rgb565::WHITE,
+            },
+            active: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::BLACK,
+                background_color: Rgb565::CYAN,
+                foreground_color: Rgb565::BLACK,
+            },
+            disabled: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::CSS_DARK_GRAY,
+                background_color: Rgb565::BLACK,
+                foreground_color: Rgb565::CSS_DARK_GRAY,
+            },
         },
     }
 }
@@ -101,23 +134,39 @@ pub fn medsize_rgb565_debug_style() -> Style<Rgb565> {
 pub fn medsize_rgb565_style() -> Style<Rgb565> {
     Style {
         background_color: Rgb565::new(0x4, 0x8, 0x4), // pretty dark gray
-        item_background_color: Rgb565::new(0x2, 0x4, 0x2), // darker gray
-        highlight_item_background_color: Rgb565::new(0x1, 0x2, 0x1),
-        border_color: Rgb565::WHITE,
-        highlight_border_color: Rgb565::WHITE,
-        primary_color: Rgb565::CSS_DARK_CYAN,
-        secondary_color: Rgb565::YELLOW,
-        icon_color: Rgb565::WHITE,
-        text_color: Rgb565::WHITE,
         default_widget_height: 16,
-        border_width: 0,
-        highlight_border_width: 1,
         default_font: mono_font::iso_8859_10::FONT_9X15,
         spacing: Spacing {
             item_spacing: Size::new(8, 4),
             button_padding: Size::new(5, 5),
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
+        },
+        widget: WidgetStyle {
+            normal: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::WHITE,
+                background_color: Rgb565::new(0x2, 0x4, 0x2), // darker gray
+                foreground_color: Rgb565::WHITE,
+            },
+            hover: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::WHITE,
+                background_color: Rgb565::new(0x1, 0x2, 0x1),
+                foreground_color: Rgb565::WHITE,
+            },
+            active: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::WHITE,
+                background_color: Rgb565::new(0x2, 0x4, 0x2), // darker gray
+                foreground_color: Rgb565::CSS_DARK_CYAN,
+            },
+            disabled: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::CSS_DARK_GRAY,
+                background_color: Rgb565::new(0x4, 0x8, 0x4), // pretty dark gray
+                foreground_color: Rgb565::CSS_DARK_GRAY,
+            },
         },
     }
 }
@@ -128,23 +177,39 @@ pub fn medsize_rgb565_style() -> Style<Rgb565> {
 pub fn medsize_light_rgb565_style() -> Style<Rgb565> {
     Style {
         background_color: Rgb565::CSS_WHITE,
-        item_background_color: Rgb565::CSS_NAVAJO_WHITE,
-        highlight_item_background_color: Rgb565::CSS_GAINSBORO,
-        border_color: Rgb565::CSS_WHITE,
-        highlight_border_color: Rgb565::CSS_BLACK,
-        primary_color: Rgb565::CSS_DARK_ORANGE,
-        secondary_color: Rgb565::YELLOW,
-        icon_color: Rgb565::CSS_BLACK,
-        text_color: Rgb565::CSS_BLACK,
         default_widget_height: 16,
-        border_width: 0,
-        highlight_border_width: 1,
         default_font: mono_font::iso_8859_10::FONT_9X15,
         spacing: Spacing {
             item_spacing: Size::new(8, 4),
             button_padding: Size::new(5, 5),
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
+        },
+        widget: WidgetStyle {
+            normal: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::CSS_WHITE,
+                background_color: Rgb565::CSS_NAVAJO_WHITE,
+                foreground_color: Rgb565::CSS_BLACK,
+            },
+            hover: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::CSS_BLACK,
+                background_color: Rgb565::CSS_GAINSBORO,
+                foreground_color: Rgb565::CSS_BLACK,
+            },
+            active: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::CSS_WHITE,
+                background_color: Rgb565::CSS_DARK_ORANGE,
+                foreground_color: Rgb565::CSS_BLACK,
+            },
+            disabled: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::CSS_LIGHT_GRAY,
+                background_color: Rgb565::CSS_LIGHT_GRAY,
+                foreground_color: Rgb565::CSS_DARK_GRAY,
+            },
         },
     }
 }
@@ -155,23 +220,39 @@ pub fn medsize_light_rgb565_style() -> Style<Rgb565> {
 pub fn medsize_sakura_rgb565_style() -> Style<Rgb565> {
     Style {
         background_color: Rgb565::CSS_PEACH_PUFF,
-        item_background_color: Rgb565::CSS_LIGHT_PINK,
-        highlight_item_background_color: Rgb565::CSS_HOT_PINK,
-        border_color: Rgb565::CSS_WHITE,
-        highlight_border_color: Rgb565::CSS_BLACK,
-        primary_color: Rgb565::CSS_DEEP_PINK,
-        secondary_color: Rgb565::YELLOW,
-        icon_color: Rgb565::CSS_BLACK,
-        text_color: Rgb565::CSS_BLACK,
         default_widget_height: 16,
-        border_width: 0,
-        highlight_border_width: 1,
         default_font: mono_font::ascii::FONT_9X15,
         spacing: Spacing {
             item_spacing: Size::new(8, 4),
             button_padding: Size::new(5, 5),
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
+        },
+        widget: WidgetStyle {
+            normal: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::WHITE,
+                background_color: Rgb565::CSS_LIGHT_PINK,
+                foreground_color: Rgb565::WHITE,
+            },
+            hover: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::CSS_BLACK,
+                background_color: Rgb565::CSS_HOT_PINK,
+                foreground_color: Rgb565::WHITE,
+            },
+            active: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::WHITE,
+                background_color: Rgb565::CSS_HOT_PINK,
+                foreground_color: Rgb565::CSS_DARK_CYAN,
+            },
+            disabled: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::CSS_DARK_GRAY,
+                background_color: Rgb565::CSS_PEACH_PUFF,
+                foreground_color: Rgb565::CSS_DARK_GRAY,
+            },
         },
     }
 }
@@ -182,23 +263,39 @@ pub fn medsize_sakura_rgb565_style() -> Style<Rgb565> {
 pub fn medsize_blue_rgb565_style() -> Style<Rgb565> {
     Style {
         background_color: Rgb565::CSS_MIDNIGHT_BLUE,
-        item_background_color: Rgb565::CSS_BLUE,
-        highlight_item_background_color: Rgb565::CSS_BLUE_VIOLET,
-        border_color: Rgb565::CSS_WHITE,
-        highlight_border_color: Rgb565::CSS_WHITE,
-        primary_color: Rgb565::CSS_PALE_VIOLET_RED,
-        secondary_color: Rgb565::YELLOW,
-        icon_color: Rgb565::CSS_WHITE,
-        text_color: Rgb565::CSS_WHITE,
         default_widget_height: 16,
-        border_width: 0,
-        highlight_border_width: 1,
         default_font: mono_font::iso_8859_10::FONT_9X15,
         spacing: Spacing {
             item_spacing: Size::new(8, 4),
             button_padding: Size::new(5, 5),
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
+        },
+        widget: WidgetStyle {
+            normal: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::CSS_WHITE,
+                background_color: Rgb565::CSS_BLUE,
+                foreground_color: Rgb565::CSS_WHITE,
+            },
+            hover: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::CSS_WHITE,
+                background_color: Rgb565::CSS_LIGHT_BLUE,
+                foreground_color: Rgb565::CSS_WHITE,
+            },
+            active: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::CSS_WHITE,
+                background_color: Rgb565::CSS_PALE_VIOLET_RED,
+                foreground_color: Rgb565::CSS_WHITE,
+            },
+            disabled: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::CSS_WHITE,
+                background_color: Rgb565::CSS_DARK_GRAY,
+                foreground_color: Rgb565::CSS_GRAY,
+            },
         },
     }
 }
@@ -209,23 +306,39 @@ pub fn medsize_blue_rgb565_style() -> Style<Rgb565> {
 pub fn medsize_crt_rgb565_style() -> Style<Rgb565> {
     Style {
         background_color: Rgb565::CSS_BLACK,
-        item_background_color: Rgb565::CSS_BLACK,
-        highlight_item_background_color: Rgb565::CSS_BLACK,
-        border_color: Rgb565::CSS_GREEN,
-        highlight_border_color: Rgb565::CSS_GREEN,
-        primary_color: Rgb565::CSS_GREEN,
-        secondary_color: Rgb565::YELLOW,
-        icon_color: Rgb565::CSS_GREEN,
-        text_color: Rgb565::CSS_GREEN,
         default_widget_height: 16,
-        border_width: 1,
-        highlight_border_width: 3,
         default_font: mono_font::iso_8859_10::FONT_9X15,
         spacing: Spacing {
             item_spacing: Size::new(8, 4),
             button_padding: Size::new(5, 5),
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
+        },
+        widget: WidgetStyle {
+            normal: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::CSS_GREEN,
+                background_color: Rgb565::CSS_BLACK,
+                foreground_color: Rgb565::CSS_GREEN,
+            },
+            hover: WidgetStyleElements {
+                border_width: 3,
+                border_color: Rgb565::CSS_GREEN,
+                background_color: Rgb565::CSS_BLACK,
+                foreground_color: Rgb565::CSS_GREEN,
+            },
+            active: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::CSS_GREEN,
+                background_color: Rgb565::CSS_GREEN,
+                foreground_color: Rgb565::CSS_BLACK,
+            },
+            disabled: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::CSS_GRAY,
+                background_color: Rgb565::CSS_BLACK,
+                foreground_color: Rgb565::CSS_GRAY,
+            },
         },
     }
 }
@@ -236,23 +349,144 @@ pub fn medsize_crt_rgb565_style() -> Style<Rgb565> {
 pub fn medsize_retro_rgb565_style() -> Style<Rgb565> {
     Style {
         background_color: Rgb565::CSS_WHITE,
-        item_background_color: Rgb565::CSS_WHITE,
-        highlight_item_background_color: Rgb565::CSS_WHITE,
-        border_color: Rgb565::CSS_BLACK,
-        highlight_border_color: Rgb565::CSS_BLACK,
-        primary_color: Rgb565::CSS_BLACK,
-        secondary_color: Rgb565::YELLOW,
-        icon_color: Rgb565::CSS_BLACK,
-        text_color: Rgb565::CSS_BLACK,
         default_widget_height: 16,
-        border_width: 1,
-        highlight_border_width: 1,
         default_font: mono_font::ascii::FONT_9X15,
         spacing: Spacing {
             item_spacing: Size::new(8, 4),
             button_padding: Size::new(5, 5),
             default_padding: Size::new(1, 1),
             window_border_padding: Size::new(3, 3),
+        },
+        widget: WidgetStyle {
+            normal: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::CSS_BLACK,
+                background_color: Rgb565::CSS_WHITE,
+                foreground_color: Rgb565::CSS_BLACK,
+            },
+            hover: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::CSS_BLACK,
+                background_color: Rgb565::CSS_WHITE,
+                foreground_color: Rgb565::CSS_BLACK,
+            },
+            active: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::CSS_WHITE,
+                background_color: Rgb565::CSS_BLACK,
+                foreground_color: Rgb565::CSS_WHITE,
+            },
+            disabled: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::CSS_GRAY,
+                background_color: Rgb565::CSS_LIGHT_GRAY,
+                foreground_color: Rgb565::CSS_GRAY,
+            },
+        },
+    }
+}
+
+/// Bootstrap-inspired theme for RGB565 displays.
+///
+/// Features a dark background with white text.
+// custom colors defined as from(Rgb888) to allow direct comparison with standard web/rgb colors and color pickers and easy conversion to other PixelColors
+pub fn medsize_bootstrap_rgb565_style() -> Style<Rgb565> {
+    Style {
+        background_color: Rgb565::CSS_BLACK,
+        widget: WidgetStyle {
+            normal: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::WHITE,
+                background_color: Rgb565::CSS_BLACK,
+                foreground_color: Rgb565::WHITE,
+            },
+            hover: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::WHITE,
+                background_color: Rgb565::CSS_LIGHT_GRAY,
+                foreground_color: Rgb565::CSS_BLACK,
+            },
+            active: WidgetStyleElements {
+                border_width: 0,
+                border_color: Rgb565::WHITE,
+                background_color: Rgb565::WHITE,
+                foreground_color: Rgb565::CSS_BLACK,
+            },
+            disabled: WidgetStyleElements {
+                border_width: 1,
+                border_color: Rgb565::CSS_DARK_GRAY,
+                background_color: Rgb565::CSS_BLACK,
+                foreground_color: Rgb565::CSS_DARK_GRAY,
+            },
+        },
+        default_widget_height: 16,
+        default_font: mono_font::ascii::FONT_9X15,
+        spacing: Spacing {
+            item_spacing: Size::new(8, 4),
+            button_padding: Size::new(5, 5),
+            default_padding: Size::new(1, 1),
+            window_border_padding: Size::new(3, 3),
+        },
+        //corner_radius: 5,
+    }
+}
+
+/// Bootstrap inspired custom Widget Style - for Primary Buttons and Widgets
+pub fn medsize_bootstrap_rgb565_primary_widget_style() -> WidgetStyle<Rgb565> {
+    WidgetStyle {
+        normal: WidgetStyleElements {
+            border_width: 0,
+            border_color: Rgb565::from(Rgb888::new(13, 110, 253)), // rgb(13,110,253)
+            background_color: Rgb565::from(Rgb888::new(13, 110, 253)), // rgb(13,110,253)
+            foreground_color: Rgb565::WHITE,
+        },
+        hover: WidgetStyleElements {
+            border_width: 0,
+            border_color: Rgb565::from(Rgb888::new(0x0b, 0x5e, 0xd7)), // #0B5ED7
+            background_color: Rgb565::from(Rgb888::new(0x0b, 0x5e, 0xd7)), // rgba(11, 94, 215, 1)
+            foreground_color: Rgb565::WHITE,
+        },
+        active: WidgetStyleElements {
+            border_width: 0,
+            border_color: Rgb565::from(Rgb888::new(10, 88, 202)), // rgb(10,88,202)
+            background_color: Rgb565::from(Rgb888::new(10, 88, 202)), // rgb(10,88,202)
+            foreground_color: Rgb565::WHITE,
+        },
+        disabled: WidgetStyleElements {
+            border_width: 0,
+            border_color: Rgb565::from(Rgb888::new(0x13, 0x54, 0xb3)), // rgba(19, 84, 179, 1)
+            background_color: Rgb565::from(Rgb888::new(0x13, 0x54, 0xb3)), // rgba(19, 84, 179, 1)
+            foreground_color: Rgb565::CSS_LIGHT_GRAY,
+        },
+    }
+}
+
+/// Bootstrap inspired custom Widget Style - for Primary Buttons and Widgets
+pub fn medsize_bootstrap_rgb565_secondary_widget_style() -> WidgetStyle<Rgb565> {
+    WidgetStyle {
+        normal: WidgetStyleElements {
+            border_width: 0,
+            border_color: Rgb565::from(Rgb888::new(108, 117, 125)), // rgb(108,117,125)
+            background_color: Rgb565::from(Rgb888::new(108, 117, 125)), // rgb(108,117,125)
+            foreground_color: Rgb565::WHITE,
+        },
+        hover: WidgetStyleElements {
+            border_width: 0,
+            border_color: Rgb565::from(Rgb888::new(92, 99, 106)), //  rgb(92, 99, 106)
+            background_color: Rgb565::from(Rgb888::new(92, 99, 106)), //  rgb(92, 99, 106)
+            foreground_color: Rgb565::WHITE,
+        },
+        active: WidgetStyleElements {
+            border_width: 0,
+            border_color: Rgb565::from(Rgb888::new(0x0a, 0x58, 0xca)), // rgb(76, 81, 91)
+            background_color: Rgb565::from(Rgb888::new(0x0a, 0x58, 0xca)), // rgb(76, 81, 91)
+            foreground_color: Rgb565::WHITE,
+        },
+        disabled: WidgetStyleElements {
+            border_width: 0,
+            border_color: Rgb565::from(Rgb888::new(81, 89, 95)), // rgb(81, 89, 95)
+            background_color: Rgb565::from(Rgb888::new(81, 89, 95)), // rgb(81, 89, 95)
+            foreground_color: Rgb565::from(Rgb888::new(177, 179, 180)), // rgb(177, 179, 180)
         },
     }
 }
@@ -298,30 +532,12 @@ pub fn medsize_retro_rgb565_style() -> Style<Rgb565> {
 pub struct Style<COL: PixelColor> {
     /// Background color for the entire UI
     pub background_color: COL,
-    /// Color used for borders around widgets
-    pub border_color: COL,
-    /// Primary accent color for interactive elements
-    pub primary_color: COL,
-    /// Secondary accent color for additional highlighting
-    pub secondary_color: COL,
-    /// Color used for icons
-    pub icon_color: COL,
     /// Default height for widgets like buttons
     pub default_widget_height: u32,
-    /// Width of borders around widgets
-    pub border_width: u32,
     /// Default font used for text rendering
     pub default_font: MonoFont<'static>,
     /// Spacing configuration for UI elements
     pub spacing: Spacing,
-    /// Background color for items like buttons
-    pub item_background_color: COL,
-    /// Background color for highlighted items
-    pub highlight_item_background_color: COL,
-    /// Border color for highlighted elements
-    pub highlight_border_color: COL,
-    /// Border width for highlighted elements
-    pub highlight_border_width: u32,
-    /// Color used for text
-    pub text_color: COL,
+    /// default styling for widgets
+    pub widget: WidgetStyle<COL>,
 }

--- a/src/toggle_button.rs
+++ b/src/toggle_button.rs
@@ -116,8 +116,8 @@ impl<'a> ToggleButton<'a> {
     }
 }
 
-impl Widget for ToggleButton<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for ToggleButton<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/toggle_button.rs
+++ b/src/toggle_button.rs
@@ -10,6 +10,7 @@
 //! with the framework's [Smartstate] system for efficient rendering.
 //!
 use crate::smartstate::{Container, Smartstate};
+use crate::style::WidgetStyle;
 use crate::ui::{GuiError, GuiResult, Interaction, Response, Ui, Widget};
 use core::cmp::max;
 use embedded_graphics::draw_target::DrawTarget;
@@ -51,13 +52,16 @@ use embedded_graphics::text::{Baseline, Text};
 ///     ui.add(ToggleButton::new("Toggle Me", &mut state));
 /// }
 /// ```
-pub struct ToggleButton<'a> {
+pub struct ToggleButton<'a, COL: PixelColor> {
     label: &'a str,
     active: &'a mut bool,
     smartstate: Container<'a, Smartstate>,
+    is_enabled: bool,
+    is_modified: bool,
+    custom_style: Option<WidgetStyle<COL>>,
 }
 
-impl<'a> ToggleButton<'a> {
+impl<'a, COL: PixelColor> ToggleButton<'a, COL> {
     /// Creates a new [ToggleButton] with the given label and active state.
     ///
     /// The `label` parameter is the text to display on the button, and the `active`
@@ -96,11 +100,14 @@ impl<'a> ToggleButton<'a> {
     ///    }
     ///
     /// }
-    pub fn new(label: &'a str, active: &'a mut bool) -> ToggleButton<'a> {
+    pub fn new(label: &'a str, active: &'a mut bool) -> ToggleButton<'a, COL> {
         ToggleButton {
             label,
             active,
             smartstate: Container::empty(),
+            is_enabled: true,
+            is_modified: false,
+            custom_style: None,
         }
     }
 
@@ -114,25 +121,53 @@ impl<'a> ToggleButton<'a> {
         self.smartstate.set(smartstate);
         self
     }
+
+    /// Enables or disables the widget - will not respond to interaction
+    ///
+    /// # Arguments
+    /// * `enabled` - if the widget should be enabled (true) or disabled(false)
+    ///
+    /// # Returns
+    /// Self with is_enabled set
+    pub fn enable(mut self, enabled: &bool) -> Self {
+        self.is_modified = true;
+        self.is_enabled = *enabled;
+        self
+    }
+
+    /// Specifies the context for the widget to determine how it is styled
+    ///
+    /// # Arguments
+    /// * `context` - Context::Normal, Context::Primary, Context::Secondary
+    ///
+    /// # Returns
+    /// Self with context set
+    pub fn with_widget_style(mut self, style: WidgetStyle<COL>) -> Self {
+        self.is_modified = true;
+        self.custom_style = Some(style);
+        self
+    }
 }
 
-impl<COL: PixelColor> Widget<COL> for ToggleButton<'_> {
+impl<COL: PixelColor> Widget<COL> for ToggleButton<'_, COL> {
     fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {
         // Prepare text
         let font = ui.style().default_font;
+        let widget_style = self.custom_style.unwrap_or_else(|| ui.style().widget);
+
         let mut text = Text::new(
             self.label,
             Point::zero(),
-            MonoTextStyle::new(&font, ui.style().text_color),
+            MonoTextStyle::new(&font, widget_style.normal.foreground_color),
         );
 
         // Determine size
         let text_bounds = text.bounding_box();
         let padding = ui.style().spacing.button_padding;
-        let border = ui.style().border_width;
+        let border = widget_style.normal.border_width;
         let height = ui.style().default_widget_height;
 
         let size = Size::new(
@@ -166,59 +201,73 @@ impl<COL: PixelColor> Widget<COL> for ToggleButton<'_> {
         // Determine styles based on state and interaction
         let prevstate = self.smartstate.clone_inner();
 
+        // Determine text color
+        text.character_style.text_color = match (*self.active, iresponse.interaction) {
+            (true, Interaction::Click(_) | Interaction::Drag(_) | Interaction::Release(_)) => {
+                Some(widget_style.active.foreground_color)
+            }
+            (true, Interaction::Hover(_)) => Some(widget_style.hover.foreground_color),
+            (true, _) => Some(widget_style.active.foreground_color),
+            (false, Interaction::Click(_) | Interaction::Drag(_) | Interaction::Release(_)) => {
+                Some(widget_style.hover.foreground_color)
+            }
+            (false, Interaction::Hover(_)) => Some(widget_style.hover.foreground_color),
+            (false, _) => Some(widget_style.normal.foreground_color),
+        };
+
         // Determine widget style
         let style = match (*self.active, iresponse.interaction) {
             (true, Interaction::Click(_) | Interaction::Drag(_) | Interaction::Release(_)) => {
                 self.smartstate.modify(|st| *st = Smartstate::state(1));
                 PrimitiveStyleBuilder::new()
-                    .stroke_color(ui.style().highlight_border_color)
-                    .stroke_width(ui.style().highlight_border_width)
-                    .fill_color(ui.style().primary_color)
+                    .stroke_color(widget_style.active.border_color)
+                    .stroke_width(widget_style.active.border_width)
+                    .fill_color(widget_style.active.background_color)
                     .build()
             }
             (true, Interaction::Hover(_)) => {
                 self.smartstate.modify(|st| *st = Smartstate::state(2));
                 PrimitiveStyleBuilder::new()
-                    .stroke_color(ui.style().highlight_border_color)
-                    .stroke_width(ui.style().highlight_border_width)
-                    .fill_color(ui.style().primary_color)
+                    .stroke_color(widget_style.hover.border_color)
+                    .stroke_width(widget_style.hover.border_width)
+                    .fill_color(widget_style.hover.background_color)
                     .build()
             }
             (true, _) => {
                 self.smartstate.modify(|st| *st = Smartstate::state(3));
                 PrimitiveStyleBuilder::new()
-                    .stroke_color(ui.style().border_color)
-                    .stroke_width(ui.style().border_width)
-                    .fill_color(ui.style().primary_color)
+                    .stroke_color(widget_style.active.border_color)
+                    .stroke_width(widget_style.active.border_width)
+                    .fill_color(widget_style.active.background_color)
                     .build()
             }
             (false, Interaction::Click(_) | Interaction::Drag(_) | Interaction::Release(_)) => {
                 self.smartstate.modify(|st| *st = Smartstate::state(4));
                 PrimitiveStyleBuilder::new()
-                    .stroke_color(ui.style().highlight_border_color)
-                    .stroke_width(ui.style().highlight_border_width)
-                    .fill_color(ui.style().primary_color)
+                    .stroke_color(widget_style.hover.border_color)
+                    .stroke_width(widget_style.hover.border_width)
+                    .fill_color(widget_style.hover.background_color)
                     .build()
             }
             (false, Interaction::Hover(_)) => {
                 self.smartstate.modify(|st| *st = Smartstate::state(5));
                 PrimitiveStyleBuilder::new()
-                    .stroke_color(ui.style().highlight_border_color)
-                    .stroke_width(ui.style().highlight_border_width)
-                    .fill_color(ui.style().highlight_item_background_color)
+                    .stroke_color(widget_style.hover.border_color)
+                    .stroke_width(widget_style.hover.border_width)
+                    .fill_color(widget_style.hover.background_color)
                     .build()
             }
             (false, _) => {
                 self.smartstate.modify(|st| *st = Smartstate::state(6));
                 PrimitiveStyleBuilder::new()
-                    .stroke_color(ui.style().border_color)
-                    .stroke_width(ui.style().border_width)
-                    .fill_color(ui.style().item_background_color)
+                    .stroke_color(widget_style.normal.border_color)
+                    .stroke_width(widget_style.normal.border_width)
+                    .fill_color(widget_style.normal.background_color)
                     .build()
             }
         };
 
-        let redraw = !self.smartstate.eq_option(&prevstate) || changed;
+        let redraw = !self.smartstate.eq_option(&prevstate) || changed || self.is_modified;
 
         if redraw {
             ui.start_drawing(&iresponse.area);
@@ -231,16 +280,24 @@ impl<COL: PixelColor> Widget<COL> for ToggleButton<'_> {
 
             ui.finalize()?;
         }
+        self.is_modified = false;
 
-        let click = matches!(iresponse.interaction, Interaction::Release(_));
-        let down = matches!(
-            iresponse.interaction,
-            Interaction::Click(_) | Interaction::Drag(_)
-        );
+        if self.is_enabled {
+            let click = matches!(iresponse.interaction, Interaction::Release(_));
+            let down = matches!(
+                iresponse.interaction,
+                Interaction::Click(_) | Interaction::Drag(_)
+            );
 
-        Ok(Response::new(iresponse)
-            .set_clicked(click)
-            .set_down(down)
-            .set_changed(changed))
+            Ok(Response::new(iresponse)
+                .set_clicked(click)
+                .set_down(down)
+                .set_changed(changed))
+        } else {
+            Ok(Response::new(iresponse)
+                .set_clicked(false)
+                .set_down(false)
+                .set_changed(false))
+        }
     }
 }

--- a/src/toggle_switch.rs
+++ b/src/toggle_switch.rs
@@ -155,8 +155,8 @@ impl<'a> ToggleSwitch<'a> {
     }
 }
 
-impl Widget for ToggleSwitch<'_> {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+impl<COL: PixelColor> Widget<COL> for ToggleSwitch<'_> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {

--- a/src/toggle_switch.rs
+++ b/src/toggle_switch.rs
@@ -10,6 +10,7 @@
 //! with the framework's [Smartstate] system for efficient rendering.
 
 use crate::smartstate::{Container, Smartstate};
+use crate::style::WidgetStyle;
 use crate::ui::{GuiError, GuiResult, Interaction, Response, Ui, Widget};
 use core::cmp::max;
 use embedded_graphics::draw_target::DrawTarget;
@@ -59,23 +60,29 @@ use embedded_graphics::primitives::{
 ///     .width(60)
 ///     .height(30));
 /// ```
-pub struct ToggleSwitch<'a> {
+pub struct ToggleSwitch<'a, COL: PixelColor> {
     active: &'a mut bool,
     smartstate: Container<'a, Smartstate>,
     width: u32,
     height: u32,
+    is_enabled: bool,
+    is_modified: bool,
+    custom_style: Option<WidgetStyle<COL>>,
 }
 
-impl<'a> ToggleSwitch<'a> {
+impl<'a, COL: PixelColor> ToggleSwitch<'a, COL> {
     /// Creates a new [ToggleSwitch] instance with the provided mutable reference to the active state.
     ///
     /// The new [ToggleSwitch] will have a default width of 50 pixels and a height of 25 pixels.
-    pub fn new(active: &'a mut bool) -> ToggleSwitch<'a> {
+    pub fn new(active: &'a mut bool) -> ToggleSwitch<'a, COL> {
         ToggleSwitch {
             active,
             smartstate: Container::empty(),
             width: 50,
             height: 25,
+            is_enabled: true,
+            is_modified: false,
+            custom_style: None,
         }
     }
 
@@ -153,13 +160,41 @@ impl<'a> ToggleSwitch<'a> {
         self.height = max(height, 15); // Enforce a minimum height
         self
     }
+
+    /// Enables or disables the widget - will not respond to interaction
+    ///
+    /// # Arguments
+    /// * `enabled` - if the widget should be enabled (true) or disabled(false)
+    ///
+    /// # Returns
+    /// Self with is_enabled set
+    pub fn enable(mut self, enabled: &bool) -> Self {
+        self.is_modified = true;
+        self.is_enabled = *enabled;
+        self
+    }
+
+    /// Specifies the context for the widget to determine how it is styled
+    ///
+    /// # Arguments
+    /// * `context` - Context::Normal, Context::Primary, Context::Secondary
+    ///
+    /// # Returns
+    /// Self with context set
+    pub fn with_widget_style(mut self, style: WidgetStyle<COL>) -> Self {
+        self.is_modified = true;
+        self.custom_style = Some(style);
+        self
+    }
 }
 
-impl<COL: PixelColor> Widget<COL> for ToggleSwitch<'_> {
+impl<COL: PixelColor> Widget<COL> for ToggleSwitch<'_, COL> {
     fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response> {
+        let widget_style = self.custom_style.unwrap_or_else(|| ui.style().widget);
+
         // Calculate total size including padding
         let padding = ui.style().spacing.button_padding;
         let total_size = Size::new(
@@ -177,24 +212,43 @@ impl<COL: PixelColor> Widget<COL> for ToggleSwitch<'_> {
             changed = true;
         }
 
-        // Colors for active and inactive states
-        let switch_color = if *self.active {
-            ui.style().primary_color
+        // Determine colors based on state
+        let switch_color: COL;
+        let knob_color: COL;
+        let border_color: COL;
+        let border_width: u32;
+
+        if self.is_enabled {
+            if *self.active {
+                switch_color = widget_style.active.background_color;
+            } else {
+                switch_color = widget_style.normal.background_color
+            };
+
+            match iresponse.interaction {
+                Interaction::Click(_) | Interaction::Drag(_) => {
+                    knob_color = widget_style.active.background_color;
+                    border_color = widget_style.active.border_color;
+                    border_width = widget_style.active.border_width;
+                }
+
+                Interaction::Hover(_) => {
+                    knob_color = widget_style.hover.background_color;
+                    border_color = widget_style.hover.border_color;
+                    border_width = widget_style.hover.border_width;
+                }
+                _ => {
+                    knob_color = widget_style.normal.background_color;
+                    border_color = widget_style.normal.border_color;
+                    border_width = widget_style.normal.border_width;
+                }
+            };
         } else {
-            ui.style().item_background_color
-        };
-
-        let knob_color = match iresponse.interaction {
-            Interaction::Click(_) | Interaction::Drag(_) => ui.style().primary_color,
-            Interaction::Hover(_) => ui.style().highlight_item_background_color,
-            _ => ui.style().item_background_color,
-        };
-
-        // Determine border color based on interaction
-        let border_color = match iresponse.interaction {
-            Interaction::Hover(_) => ui.style().highlight_border_color,
-            _ => ui.style().border_color,
-        };
+            switch_color = widget_style.disabled.background_color;
+            knob_color = widget_style.disabled.background_color;
+            border_color = widget_style.disabled.border_color;
+            border_width = widget_style.disabled.border_width;
+        }
 
         // Inside the draw method, replace the current smartstate handling with:
 
@@ -213,7 +267,7 @@ impl<COL: PixelColor> Widget<COL> for ToggleSwitch<'_> {
         self.smartstate.modify(|st| *st = Smartstate::state(state));
 
         // Determine if redraw is needed based on state change or active state change
-        let redraw = !self.smartstate.eq_option(&prevstate) || changed;
+        let redraw = !self.smartstate.eq_option(&prevstate) || changed || self.is_modified;
 
         if redraw {
             ui.start_drawing(&iresponse.area);
@@ -231,25 +285,25 @@ impl<COL: PixelColor> Widget<COL> for ToggleSwitch<'_> {
             let switch_style = PrimitiveStyleBuilder::new()
                 .fill_color(switch_color)
                 .stroke_color(border_color)
-                .stroke_width(ui.style().border_width)
+                .stroke_width(border_width)
                 .build();
 
             ui.draw(&switch_rect.into_styled(switch_style))
                 .map_err(|_| GuiError::DrawError(Some("Couldn't draw ToggleSwitch background")))?;
 
             // Calculate knob position
-            let knob_radius = (self.height / 2) - ui.style().border_width;
+            let knob_radius = (self.height / 2) - border_width;
             let knob_x = if *self.active {
                 // Positioned on the right
                 iresponse.area.top_left.x + padding.width as i32 + self.width as i32
                     - knob_radius as i32
-                    - ui.style().border_width as i32
+                    - border_width as i32
             } else {
                 // Positioned on the left
                 iresponse.area.top_left.x
                     + padding.width as i32
                     + knob_radius as i32
-                    + ui.style().border_width as i32
+                    + border_width as i32
             };
 
             let knob_center = Point::new(
@@ -270,16 +324,24 @@ impl<COL: PixelColor> Widget<COL> for ToggleSwitch<'_> {
 
             ui.finalize()?;
         }
+        self.is_modified = false;
 
-        let click = matches!(iresponse.interaction, Interaction::Release(_));
-        let down = matches!(
-            iresponse.interaction,
-            Interaction::Click(_) | Interaction::Drag(_)
-        );
+        if self.is_enabled {
+            let click = matches!(iresponse.interaction, Interaction::Release(_));
+            let down = matches!(
+                iresponse.interaction,
+                Interaction::Click(_) | Interaction::Drag(_)
+            );
 
-        Ok(Response::new(iresponse)
-            .set_clicked(click)
-            .set_down(down)
-            .set_changed(changed))
+            Ok(Response::new(iresponse)
+                .set_clicked(click)
+                .set_down(down)
+                .set_changed(changed))
+        } else {
+            Ok(Response::new(iresponse)
+                .set_clicked(false)
+                .set_down(false)
+                .set_changed(false))
+        }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -155,8 +155,8 @@ impl Response {
     }
 }
 
-pub trait Widget {
-    fn draw<DRAW: DrawTarget<Color = COL>, COL: PixelColor>(
+pub trait Widget<COL: PixelColor> {
+    fn draw<DRAW: DrawTarget<Color = COL>>(
         &mut self,
         ui: &mut Ui<DRAW, COL>,
     ) -> GuiResult<Response>;
@@ -774,7 +774,11 @@ where
     /// # let mut widget = Label::new("Hi");
     /// let response = ui.add_and_clear_col_remainder(widget, true);
     /// ```
-    pub fn add_and_clear_col_remainder(&mut self, widget: impl Widget, clear: bool) -> Response {
+    pub fn add_and_clear_col_remainder(
+        &mut self,
+        widget: impl Widget<COL>,
+        clear: bool,
+    ) -> Response {
         let resp = self.add_raw(widget).unwrap_or_else(Response::from_error);
         if clear {
             self.clear_row_to_end().ok();
@@ -810,7 +814,7 @@ where
     /// # let mut widget = Label::new("Hi");
     /// let response = ui.add(widget);
     /// ```
-    pub fn add(&mut self, widget: impl Widget) -> Response {
+    pub fn add(&mut self, widget: impl Widget<COL>) -> Response {
         let resp = self.add_raw(widget).unwrap_or_else(Response::from_error);
         self.new_row();
         resp
@@ -843,7 +847,7 @@ where
     /// # let mut widget = Label::new("Hi");
     /// let response = ui.add_centered(widget);
     /// ```
-    pub fn add_centered(&mut self, widget: impl Widget) -> Response {
+    pub fn add_centered(&mut self, widget: impl Widget<COL>) -> Response {
         let align = self.placer.align;
         self.placer.align = Align(HorizontalAlign::Center, align.1);
         let resp = self.add_raw(widget).unwrap_or_else(Response::from_error);
@@ -879,7 +883,7 @@ where
     /// # let mut widget = Label::new("Hi");
     /// let response = ui.add_horizontal(widget);
     /// ```
-    pub fn add_horizontal(&mut self, widget: impl Widget) -> Response {
+    pub fn add_horizontal(&mut self, widget: impl Widget<COL>) -> Response {
         let resp = self.add_raw(widget).unwrap_or_else(Response::from_error);
         // Allocate space between widgets; ignore space errors.
         self.allocate_space_no_wrap(self.style().spacing.item_spacing)
@@ -917,7 +921,7 @@ where
     ///     Err(e) => { /* handle error */ },
     /// }
     /// ```
-    pub fn add_raw(&mut self, mut widget: impl Widget) -> GuiResult<Response> {
+    pub fn add_raw(&mut self, mut widget: impl Widget<COL>) -> GuiResult<Response> {
         let res = widget.draw(self);
         if let (Ok(res), Some(debug_color)) = (&res, self.debug_color) {
             res.internal


### PR DESCRIPTION
This PR adds a disabled state to interactive widgets (issue #16 )
It also adds new visual styling (border and colors) for the disabled state and refactors Style to move all widget appearance settings to a new struct which contains a visual style setting for every widget state (normal, hover, active, disabled). (issue #17 )
